### PR TITLE
fix: guests toolbar wrapping on narrow layouts

### DIFF
--- a/src/pages/dashboard/Guests.tsx
+++ b/src/pages/dashboard/Guests.tsx
@@ -1517,7 +1517,7 @@ Proceed with send?`)) return;
                   onChange={(e) => setSearchQuery(e.target.value)}
                 />
               </div>
-              <div className="flex gap-3">
+              <div className="flex gap-2 flex-wrap items-start [&>*]:whitespace-nowrap">
                 <label className="cursor-pointer">
                   <input
                     type="file"


### PR DESCRIPTION
## Summary\n- wrap Guests action toolbar controls so buttons no longer clip on narrower widths\n- keep controls readable and intact in demo/admin view\n\n## Validation\n- npm run verify (typecheck + build) passed locally\n\n## Notes\n- branch-only for preview validation (no production deploy)