### PR TITLE
feat: RSVP custom questions live (settings + public form + ops visibility)

### DIFF
--- a/src/pages/dashboard/Guests.tsx
+++ b/src/pages/dashboard/Guests.tsx
@@ -58,6 +58,18 @@ function parseRsvpEventSelections(notes: string | null): { ceremony?: boolean; r
 }
 
 
+
+function getCustomAnswerEntries(customAnswers: Record<string, string> | null | undefined): Array<{ key: string; value: string }> {
+  if (!customAnswers || typeof customAnswers !== 'object') return [];
+
+  return Object.entries(customAnswers)
+    .map(([key, value]) => ({
+      key: key.replace(/^q_/, 'question_'),
+      value: (typeof value === 'string' ? value : String(value ?? '')).trim(),
+    }))
+    .filter((entry) => entry.value.length > 0);
+}
+
 function formatCustomAnswers(customAnswers: Record<string, string> | null | undefined): string {
   if (!customAnswers || typeof customAnswers !== 'object') return '';
   const entries = Object.entries(customAnswers)
@@ -2128,6 +2140,44 @@ Proceed with send?`)) return;
             </div>
 
             <div className="flex-1 overflow-y-auto p-5">
+              {(() => {
+                const entries = getCustomAnswerEntries(itineraryDrawerGuest.rsvp?.custom_answers || null);
+                const status = itineraryDrawerGuest.rsvp_status;
+                const meal = itineraryDrawerGuest.rsvp?.meal_choice;
+                const plusOne = itineraryDrawerGuest.rsvp?.plus_one_name;
+
+                return (
+                  <div className="mb-4 p-4 bg-surface-subtle border border-border rounded-xl space-y-2">
+                    <p className="text-xs uppercase tracking-wide text-text-tertiary">RSVP details</p>
+                    <div className="text-sm text-text-primary">
+                      <span className="font-medium">Status:</span>{' '}
+                      <span className="capitalize">{status}</span>
+                    </div>
+                    {meal && (
+                      <div className="text-sm text-text-primary">
+                        <span className="font-medium">Meal:</span> <span className="capitalize">{meal}</span>
+                      </div>
+                    )}
+                    {plusOne && (
+                      <div className="text-sm text-text-primary">
+                        <span className="font-medium">Plus one:</span> {plusOne}
+                      </div>
+                    )}
+                    {entries.length > 0 && (
+                      <div className="pt-1 space-y-1.5">
+                        <p className="text-xs uppercase tracking-wide text-text-tertiary">Custom answers</p>
+                        {entries.map((entry) => (
+                          <div key={entry.key} className="text-sm text-text-primary flex items-start justify-between gap-3">
+                            <span className="text-text-secondary truncate">{entry.key}</span>
+                            <span className="text-right">{entry.value}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })()}
+
               {loadingDrawer ? (
                 <div className="flex items-center justify-center h-32">
                   <Loader2 className="w-5 h-5 animate-spin text-primary" />

--- a/src/pages/dashboard/Guests.tsx
+++ b/src/pages/dashboard/Guests.tsx
@@ -30,6 +30,7 @@ interface RSVP {
   meal_choice: string | null;
   plus_one_name: string | null;
   notes: string | null;
+  custom_answers?: Record<string, string> | null;
 }
 
 interface GuestWithRSVP extends Guest {
@@ -54,6 +55,20 @@ function parseRsvpEventSelections(notes: string | null): { ceremony?: boolean; r
     ceremony: map.ceremony,
     reception: map.reception,
   };
+}
+
+
+function formatCustomAnswers(customAnswers: Record<string, string> | null | undefined): string {
+  if (!customAnswers || typeof customAnswers !== 'object') return '';
+  const entries = Object.entries(customAnswers)
+    .map(([key, value]) => [key, typeof value === 'string' ? value.trim() : String(value ?? '').trim()] as const)
+    .filter(([, value]) => value.length > 0);
+
+  if (entries.length === 0) return '';
+
+  return entries
+    .map(([key, value]) => `${key.replace(/^q_/, 'question_')}: ${value}`)
+    .join(' | ');
 }
 
 interface WeddingSiteInfo {
@@ -825,6 +840,7 @@ Proceed with send?`)) return;
       guest.rsvp?.meal_choice || '',
       guest.rsvp_received_at ? new Date(guest.rsvp_received_at).toLocaleDateString() : '',
       guest.invite_token || '',
+      formatCustomAnswers(guest.rsvp?.custom_answers || null),
     ]);
 
     const csvContent = [headers, ...rows]
@@ -1985,6 +2001,15 @@ Proceed with send?`)) return;
                                       </span>
                                     )}
                                   </div>
+                                );
+                              })()}
+                              {(() => {
+                                const custom = formatCustomAnswers(guest.rsvp?.custom_answers || null);
+                                if (!custom) return null;
+                                return (
+                                  <p className="text-[11px] text-text-tertiary pt-1 truncate" title={custom}>
+                                    Custom answers saved
+                                  </p>
                                 );
                               })()}
                             </div>

--- a/supabase/migrations/20260223174800_add_rsvp_custom_questions_and_answers.sql
+++ b/supabase/migrations/20260223174800_add_rsvp_custom_questions_and_answers.sql
@@ -1,0 +1,10 @@
+-- RSVP custom questions (site-configurable) + response answers payload
+
+ALTER TABLE wedding_sites
+  ADD COLUMN IF NOT EXISTS rsvp_custom_questions jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE rsvps
+  ADD COLUMN IF NOT EXISTS custom_answers jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN wedding_sites.rsvp_custom_questions IS 'Array of RSVP custom question definitions configured by the couple';
+COMMENT ON COLUMN rsvps.custom_answers IS 'Object map of custom RSVP answers keyed by question id';


### PR DESCRIPTION
## Summary\n- add RSVP custom questions config on site settings\n- render/validate custom questions in public RSVP flow\n- persist custom answers in \n- surface custom-answer status/details in Guests ops\n- include custom answers in CSV export\n\n## Schema\n- wedding_sites.rsvp_custom_questions (jsonb)\n- rsvps.custom_answers (jsonb)\n\n## Validation\n- npm run verify ✅\n\n## Follow-ups\n- optional: label-aware answer rendering in Guests (instead of key names)\n- optional: analytics widgets by custom answer