### PR TITLE
Fix dead registry demo image URL in featured variant

### DIFF
--- a/src/sections/variants/registry/featured.tsx
+++ b/src/sections/variants/registry/featured.tsx
@@ -77,7 +77,7 @@ export const defaultRegistryFeaturedData: RegistryFeaturedData = {
       store: 'Williams Sonoma',
       price: '$500',
       description: 'In Matte Black — for weekend baking projects',
-      image: 'https://images.pexels.com/photos/4224218/pexels-photo-4224218.jpeg?auto=compress&cs=tinysrgb&w=600',
+      image: 'https://images.pexels.com/photos/1024993/pexels-photo-1024993.jpeg?auto=compress&cs=tinysrgb&w=600',
       url: '#',
       category: 'Kitchen',
       isPriority: false,


### PR DESCRIPTION
## Root cause\nA stale external Pexels URL in  default demo data returned 404, causing console errors in headless preview checks for  and .\n\n## Fix\n- Replace dead image URL with a known live demo image URL.\n\n## Validation\n- npm run typecheck\n- npm run build\n- Headless Playwright check for  and  confirms no 404 responses.