### PR TITLE
Add regression guard for critical variant resolution

### DIFF
--- a/src/sections/registry.test.ts
+++ b/src/sections/registry.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getAllSectionManifests } from '../builder/registry/sectionManifests';
+import { resolveAndParse } from './registry';
+
+const EXPECTED_ALIAS_TARGETS: Array<{ type: string; variant: string; expectedResolvedVariant: string }> = [
+  { type: 'venue', variant: 'banner', expectedResolvedVariant: 'splitMap' },
+  { type: 'venue', variant: 'stacked', expectedResolvedVariant: 'detailsFirst' },
+  { type: 'venue', variant: 'minimal', expectedResolvedVariant: 'card' },
+  { type: 'directions', variant: 'illustrated', expectedResolvedVariant: 'split' },
+  { type: 'directions', variant: 'multiVenue', expectedResolvedVariant: 'split' },
+  { type: 'directions', variant: 'transport', expectedResolvedVariant: 'pin' },
+  { type: 'directions', variant: 'fromHotel', expectedResolvedVariant: 'pin' },
+  { type: 'registry', variant: 'fundHighlight', expectedResolvedVariant: 'featured' },
+  { type: 'registry', variant: 'honeymoon', expectedResolvedVariant: 'featured' },
+  { type: 'registry', variant: 'tabs', expectedResolvedVariant: 'cards' },
+  { type: 'registry', variant: 'illustrated', expectedResolvedVariant: 'cards' },
+  { type: 'registry', variant: 'minimal', expectedResolvedVariant: 'cards' },
+];
+
+describe('sections registry resolution', () => {
+  it('resolves all supported variants for high-risk section types touched by recent fixes', () => {
+    const guardedTypes = new Set(['gallery', 'venue', 'directions', 'registry']);
+    const manifests = getAllSectionManifests().filter((m) => guardedTypes.has(m.type));
+
+    for (const manifest of manifests) {
+      for (const variant of manifest.supportedVariants) {
+        const resolved = resolveAndParse(manifest.type, variant, {});
+        expect(resolved, `unresolved ${manifest.type}:${variant}`).not.toBeNull();
+      }
+    }
+  });
+
+  it('keeps explicit alias fallback mappings stable for critical variants', () => {
+    for (const { type, variant, expectedResolvedVariant } of EXPECTED_ALIAS_TARGETS) {
+      const resolved = resolveAndParse(type, variant, {});
+      expect(resolved, `unresolved alias ${type}:${variant}`).not.toBeNull();
+      expect(resolved?.def.variant).toBe(expectedResolvedVariant);
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- Add  to guard variant resolution behavior for recently fixed high-risk section types.\n- Verifies all supported variants resolve for: gallery, venue, directions, registry.\n- Locks explicit alias mappings for map/registry variants to expected renderer targets.\n\n## Validation\n- npm run test -- src/sections/registry.test.ts\n- npm run typecheck\n- npm run build\n- Headless preview sweep for 18 touched variants (all pass, no errors/404s).