### PR TITLE
Stabilize test env and RSVP smoke env parsing

### DIFF
--- a/scripts/rsvp_smoke.js
+++ b/scripts/rsvp_smoke.js
@@ -1,19 +1,35 @@
 import fs from 'node:fs';
 
-const env = Object.fromEntries(
-  fs.readFileSync('.env.local', 'utf8')
-    .split('\n')
-    .map((l) => l.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const i = line.indexOf('=');
-      return [line.slice(0, i), line.slice(i + 1)];
-    })
-);
+const normalizeEnvValue = (value) => {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim().replace(/[\r\n]+/g, '');
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+};
 
-const base = env.VITE_SUPABASE_URL;
-const key = env.VITE_SUPABASE_ANON_KEY;
+const fileEnv = fs.existsSync('.env.local')
+  ? Object.fromEntries(
+      fs.readFileSync('.env.local', 'utf8')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((line) => line && !line.startsWith('#') && line.includes('='))
+        .map((line) => {
+          const i = line.indexOf('=');
+          return [line.slice(0, i), normalizeEnvValue(line.slice(i + 1))];
+        })
+    )
+  : {};
+
+const base = normalizeEnvValue(process.env.VITE_SUPABASE_URL || fileEnv.VITE_SUPABASE_URL);
+const key = normalizeEnvValue(process.env.VITE_SUPABASE_ANON_KEY || fileEnv.VITE_SUPABASE_ANON_KEY);
 const strict = process.argv.includes('--strict');
+
+if (!base || !key) {
+  console.log(JSON.stringify({ ok: false, step: 'env_missing', message: 'VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY missing' }, null, 2));
+  process.exit(1);
+}
 
 async function req(url, opts = {}) {
   const res = await fetch(url, {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// Ensure modules that import the shared Supabase client can load in CI/unit tests
+// without requiring real project secrets.
+vi.stubEnv('VITE_SUPABASE_URL', process.env.VITE_SUPABASE_URL || 'https://example.supabase.co');
+vi.stubEnv('VITE_SUPABASE_ANON_KEY', process.env.VITE_SUPABASE_ANON_KEY || 'test-anon-key');


### PR DESCRIPTION
## Summary\n- Add Supabase env stubs in Vitest setup so modules importing the shared Supabase client can load in CI/unit tests.\n- Harden  env parsing by trimming/normalizing values and removing surrounding quotes/newlines.\n\n## Why\n- PR #52 added a registry resolution test that imports section definitions pulling in registry modules and Supabase client initialization. CI lacked runtime env values there and failed before tests could run.\n- Existing smoke script was fragile to quoted/newline env formatting.\n\n## Validation\n- npm run test -- src/sections/registry.test.ts\n- npm run typecheck\n- npm run build