### PR TITLE
CI: gate Supabase RSVP smoke on secrets + Node 24

### DIFF
--- a/.github/workflows/ci-hardpass.yml
+++ b/.github/workflows/ci-hardpass.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install
@@ -31,5 +31,16 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Hardpass RSVP/CSV
-        run: npm run hardpass:rsvp
+      - name: Hardpass core (tests/build/csv/checkin)
+        run: npm test && npm run build && npm run smoke:csvmapper && npm run smoke:checkin
+
+      - name: Hardpass RSVP strict (Supabase-backed)
+        if: ${{ secrets.VITE_SUPABASE_URL != '' && secrets.VITE_SUPABASE_ANON_KEY != '' }}
+        run: npm run smoke:rsvp:strict
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+
+      - name: RSVP strict skipped notice
+        if: ${{ !(secrets.VITE_SUPABASE_URL != '' && secrets.VITE_SUPABASE_ANON_KEY != '') }}
+        run: echo "Skipping smoke:rsvp:strict (missing VITE_SUPABASE_URL/VITE_SUPABASE_ANON_KEY secrets)."


### PR DESCRIPTION
## Summary\n- Split hardpass workflow into core checks and Supabase-backed RSVP strict smoke.\n- Run RSVP strict only when  and  secrets are present.\n- Add explicit skip notice when secrets are missing.\n- Bump workflow Node from 20 to 24 to stay ahead of Actions deprecation notices.\n\n## Why\n- Main was failing on  due to missing Supabase env in GitHub Actions.\n- Core quality gates should stay green without external secret dependency, while preserving strict smoke when credentials are configured.