### PR TITLE
CI: force GitHub Actions JS runtime to Node 24

### DIFF
--- a/.github/workflows/ci-hardpass.yml
+++ b/.github/workflows/ci-hardpass.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   hardpass-rsvp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds  at workflow env level to opt into Node 24 immediately and remove Node 20 deprecation noise for actions/checkout and actions/setup-node internals.