### PR TITLE
CI: upgrade GitHub Actions to v6 runtimes

### DIFF
--- a/.github/workflows/ci-hardpass.yml
+++ b/.github/workflows/ci-hardpass.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
Upgrades  and  from v4 to v6 to align with Node 24 era and remove Node 20 deprecation warnings.