### PR TITLE
Align live smoke homepage CTA

### DIFF
--- a/tests/e2e/live-smoke.spec.ts
+++ b/tests/e2e/live-smoke.spec.ts
@@ -13,7 +13,7 @@ test.describe('public v1 trust smoke', () => {
     await expect(page.getByText(/Core v1 today/i)).toBeVisible();
     await expect(page.getByText(/Should ship/i)).toBeVisible();
     await expect(page.getByText(/Cut from promise/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /sign up for your wedding site|start your site/i }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /start your wedding site draft|sign up for your wedding site|start your site/i }).first()).toBeVisible();
   });
 
   test('product page exposes the real v1 line instead of the wishlist', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Update the production live smoke to accept the current homepage CTA label: Start your wedding site draft.
- Keeps older accepted CTA labels in the matcher so the smoke stays compatible with prior public copy.

## Verification
- PLAYWRIGHT_BASE_URL=https://dayof.love npm run test:e2e:live
- PLAYWRIGHT_BASE_URL=https://dayof.love npm run proof:v1:canonical-smoke with existing local Supabase env loaded
- git diff --check

No deploy was run.