### PR TITLE
Fix public site secretless loading

### DIFF
--- a/docs/v1-smoke-proof-log.md
+++ b/docs/v1-smoke-proof-log.md
@@ -130,6 +130,10 @@ If the product cannot be shown, shared, and trusted publicly, the v1 claim is de
 **Pass / Fail**
 - Status: AUTOMATED_PASS / MANUAL_NOTES_PENDING
 - Notes:
+  - 2026-05-20 17:50 PDT manual live truth pass found a launch blocker on the public site route: `https://dayof.love/site/alex-jordan-demo` and `https://alex-jordan-demo.dayof.love/` rendered `Something went wrong` / `Failed to load wedding site`, even though the Supabase slug lookup smoke resolved `alex-jordan-demo`.
+  - Root cause isolated locally: public site runtime selected secret privacy fields (`site_password_hash`, `guest_access_token`) and the wedding-data parser assumed an empty `wedding_data` object had a `couple` shape before `normalizeWeddingData` could repair it.
+  - Local fix verified on production preview at `http://127.0.0.1:4177/site/alex-jordan-demo`: the route rendered public site content with RSVP available, no `Something went wrong` state, and no failed Supabase responses.
+  - Fix is not live until its PR is merged and deployed; live production still needs a post-deploy recheck of `/site/alex-jordan-demo`.
   - 2026-04-21 automated canonical smoke passed via `npm run proof:v1:canonical-smoke`.
   - `npm run test:e2e:live` passed across Home, Product, Trust, Login, RSVP entry, and collaborator invite route load.
   - Canonical route smoke now also covers signup load, payment gate auth fallback, quick-start preview reachability, and login fallback behavior across protected onboarding, setup, and dashboard surfaces when auth is missing.

--- a/src/data/siteRepository.ts
+++ b/src/data/siteRepository.ts
@@ -46,8 +46,6 @@ export const siteRepository = {
       'default_language',
       'privacy_mode',
       'hide_from_search',
-      'site_password_hash',
-      'guest_access_token',
     ].join(',');
 
     const bySlug = await supabase
@@ -88,6 +86,22 @@ export const siteRepository = {
     if (match) return match as unknown as Record<string, unknown>;
 
     return null;
+  },
+
+  async verifyPublicInviteAccess(slugInput: string, tokenInput: string): Promise<boolean> {
+    const slug = normalizePublicSiteSlug(slugInput);
+    const token = typeof tokenInput === 'string' ? tokenInput.trim() : '';
+    if (!slug || !token) return false;
+
+    const { data, error } = await supabase
+      .from('wedding_sites')
+      .select('id')
+      .eq('site_slug', slug)
+      .eq('guest_access_token', token)
+      .maybeSingle();
+
+    if (error) return false;
+    return Boolean(data);
   },
 
   async fetchSections(siteId: string): Promise<PersistedSection[]> {

--- a/src/lib/publicSiteProject.test.ts
+++ b/src/lib/publicSiteProject.test.ts
@@ -507,4 +507,21 @@ describe('publicSiteProject', () => {
 
     expect(getPublicWeddingData(row)?.couple.displayName).toBe('Draft Names');
   });
+
+  it('does not throw when live wedding_data is an empty object', () => {
+    const row = {
+      is_published: true,
+      site_json: {
+        ...draftProject,
+        weddingDataSnapshot: '',
+      },
+      published_json: {
+        ...publishedProject,
+        weddingDataSnapshot: 'not-json',
+      },
+      wedding_data: {},
+    };
+
+    expect(getPublicWeddingData(row)).toEqual({});
+  });
 });

--- a/src/lib/publicSiteProject.ts
+++ b/src/lib/publicSiteProject.ts
@@ -15,6 +15,8 @@ const asRecord = (value: unknown): Record<string, unknown> | null => {
 };
 
 const withTruthfulCoupleDisplayName = (data: WeddingDataV1): WeddingDataV1 => {
+  if (!data.couple) return data;
+
   const displayName = data.couple.displayName
     || buildCoupleDisplayName(data.couple.partner1Name, data.couple.partner2Name);
 

--- a/src/pages/SiteView.tsx
+++ b/src/pages/SiteView.tsx
@@ -493,15 +493,13 @@ export const SiteView: React.FC = () => {
           return;
         }
 
-        const pwHash = (data.site_password_hash as string | null) ?? null;
         const hideSearch = !!(data.hide_from_search);
-        const guestToken = (data.guest_access_token as string | null) ?? null;
 
         setHideFromSearch(hideSearch);
 
         if (privacyMode === 'password_protected') {
           const alreadyUnlocked = sessionStorage.getItem(`dayof_pw_unlocked_${resolvedSlug}`) === '1';
-          if (!pwHash || !alreadyUnlocked) {
+          if (!alreadyUnlocked) {
             setPrivacyGate('password_required');
             setLoading(false);
             return;
@@ -510,7 +508,10 @@ export const SiteView: React.FC = () => {
           const urlToken = searchParams.get('token');
           const storedToken = sessionStorage.getItem(`dayof_invite_token_${resolvedSlug}`);
           const tokenToCheck = urlToken ?? storedToken;
-          if (!guestToken || !tokenToCheck || tokenToCheck !== guestToken) {
+          const hasInviteAccess = tokenToCheck
+            ? await siteRepository.verifyPublicInviteAccess(resolvedSlug, tokenToCheck)
+            : false;
+          if (!hasInviteAccess) {
             setPrivacyGate('invite_only');
             setLoading(false);
             return;


### PR DESCRIPTION
## Summary
- Stop the public site runtime from selecting secret privacy fields in the anonymous public-site query.
- Validate invite-only access through an id-only token match instead of returning the token to the browser.
- Harden public wedding-data parsing when live wedding_data is an empty object.
- Log the manual truth-pass finding and local verification in docs/v1-smoke-proof-log.md.

## Verification
- npm test -- src/lib/publicSiteProject.test.ts
- npm run typecheck -- --pretty false
- npm run build
- git diff --check
- Local production preview with env loaded: http://127.0.0.1:4177/site/alex-jordan-demo rendered public site content with RSVP available, no error page, and no failed Supabase responses.

No deploy was run.