### PR TITLE
Fix demo dashboard visibility truth

### DIFF
--- a/docs/v1-smoke-proof-log.md
+++ b/docs/v1-smoke-proof-log.md
@@ -502,3 +502,8 @@ A slice does **not** count as passed because:
 - Public promise is much cleaner than before.
 - The repo is now closer to **truthful** than **proven**.
 - The main finish risk is no longer fake copy; it is missing proof on the must-ship flows.
+
+## 2026-05-20 18:17 PDT - Demo Dashboard Visibility Truth Fix
+
+- Concrete finish gap found and fixed: the demo dashboard sidebar still said the Alex/Jordan site was draft-only while the builder and public demo route treated it as live. Demo mode now hydrates the shared dashboard shell with the published public visibility state, search-visible status, real demo site id, and owner role so the overview/sidebar does not contradict the live public demo.
+- Verification: `npm test -- src/components/dashboard/dashboardDemoContext.test.ts` passed, `npm run typecheck -- --pretty false` passed, `npm run build` passed, and `git diff --check` passed. The first heavier component-render test attempt hung during local Vitest startup, so the final regression is a pure helper test that covers the same demo visibility truth without jsdom lifecycle noise. No deploy was run.

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -31,6 +31,7 @@ import { resolvePublicSiteSlugFromRow } from '../../lib/publicSiteSlug';
 import { getSiteVisibilityState } from '../../lib/siteVisibilityState';
 import { resolveActiveSiteForUser, resolveActiveSiteRoleForUser } from '../../lib/activeSite';
 import { getStoredActiveSiteId, setStoredActiveSiteId } from '../../lib/activeSiteStorage';
+import { getDemoDashboardSiteContext } from './dashboardDemoContext';
 import { buildSiteMembershipLabel } from './siteMembershipLabel';
 
 interface DashboardLayoutProps {
@@ -65,7 +66,13 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, curr
     if (!user) return;
 
     if (isDemoMode) {
-      setSiteSlug('alex-jordan-demo');
+      const demoSiteContext = getDemoDashboardSiteContext();
+      setSiteSlug(demoSiteContext.siteSlug);
+      setSiteId(demoSiteContext.siteId);
+      setSiteIsPublished(demoSiteContext.isPublished);
+      setSitePrivacyMode(demoSiteContext.privacyMode);
+      setSiteJsonState(demoSiteContext.siteJson);
+      setActiveSiteRole(demoSiteContext.role);
       return;
     }
 

--- a/src/components/dashboard/dashboardDemoContext.test.ts
+++ b/src/components/dashboard/dashboardDemoContext.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSiteVisibilityState } from '../../lib/siteVisibilityState';
+import { getDemoDashboardSiteContext } from './dashboardDemoContext';
+
+describe('demo dashboard site context', () => {
+  it('hydrates the public demo as a live visible site', () => {
+    const demoContext = getDemoDashboardSiteContext();
+    const visibility = getSiteVisibilityState({
+      isPublished: demoContext.isPublished,
+      privacyMode: demoContext.privacyMode,
+      hideFromSearch: demoContext.siteJson.hide_from_search,
+    });
+
+    expect(demoContext).toMatchObject({
+      siteSlug: 'alex-jordan-demo',
+      siteId: 'demo-site-id',
+      role: 'owner',
+    });
+    expect(visibility.label).toBe('Live and visible to guests');
+    expect(visibility.searchLabel).toBe('Search visibility on');
+    expect(visibility.explainer).toBe('The site is live for guests at your DayOf URL.');
+  });
+});

--- a/src/components/dashboard/dashboardDemoContext.ts
+++ b/src/components/dashboard/dashboardDemoContext.ts
@@ -1,0 +1,12 @@
+import { demoWeddingSite } from '../../lib/demoData';
+
+export function getDemoDashboardSiteContext() {
+  return {
+    siteSlug: 'alex-jordan-demo',
+    siteId: demoWeddingSite.id,
+    isPublished: true,
+    privacyMode: 'public' as const,
+    siteJson: { hide_from_search: false },
+    role: 'owner' as const,
+  };
+}


### PR DESCRIPTION
## Summary
- Hydrates the demo dashboard shell with the published public visibility state for the Alex/Jordan demo site.
- Adds a fast pure regression so the demo sidebar context cannot drift back to draft-only while the public demo is live.
- Logs the proof note with the local verification and no-deploy status.

## Verification
- `npm test -- src/components/dashboard/dashboardDemoContext.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run build`
- `git diff --check`
- `npm run proof:v1:board:md`

No deploy was run.
