### PR TITLE
Align coordinator demo site id

### DIFF
--- a/docs/v1-smoke-proof-log.md
+++ b/docs/v1-smoke-proof-log.md
@@ -507,3 +507,8 @@ A slice does **not** count as passed because:
 
 - Concrete finish gap found and fixed: the demo dashboard sidebar still said the Alex/Jordan site was draft-only while the builder and public demo route treated it as live. Demo mode now hydrates the shared dashboard shell with the published public visibility state, search-visible status, real demo site id, and owner role so the overview/sidebar does not contradict the live public demo.
 - Verification: `npm test -- src/components/dashboard/dashboardDemoContext.test.ts` passed, `npm run typecheck -- --pretty false` passed, `npm run build` passed, and `git diff --check` passed. The first heavier component-render test attempt hung during local Vitest startup, so the final regression is a pure helper test that covers the same demo visibility truth without jsdom lifecycle noise. No deploy was run.
+
+## 2026-05-20 18:38 PDT - Coordinator Demo Site Id Consistency Fix
+
+- Concrete finish gap found and fixed: Coordinator Mode demo state was still persisted under `demo-site`, while the shared demo site and other dashboard surfaces use `demo-site-id`. Coordinator demo mode now reads the shared demo site id so local coordinator timeline, Q&A, alert, role, and command state keys do not fork away from the rest of the Alex/Jordan demo.
+- Verification: `npm test -- src/pages/dashboard/coordinatorDemoContext.test.ts` passed, `npm run typecheck -- --pretty false` passed, `npm run build` passed, and `git diff --check` passed. No deploy was run.

--- a/src/pages/dashboard/CoordinatorMode.tsx
+++ b/src/pages/dashboard/CoordinatorMode.tsx
@@ -117,6 +117,7 @@ import { buildCoordinatorPrimaryActionBoard } from '../../lib/coordinatorPrimary
 import { buildCoordinatorExecutionBoard } from '../../lib/coordinatorExecutionBoard';
 import { buildCoordinatorAlertLogView } from '../../lib/coordinatorAlertLogView';
 import { buildCoordinatorNavigationBoard } from '../../lib/coordinatorNavigationBoard';
+import { getCoordinatorDemoSiteId } from './coordinatorDemoContext';
 
 
 type AudienceOption = { value: string; label: string; count: number };
@@ -206,7 +207,7 @@ export const DashboardCoordinatorMode: React.FC = () => {
         if (isDemoMode) {
           if (!mounted) return;
           const now = new Date().toISOString();
-          setSiteId('demo-site');
+          setSiteId(getCoordinatorDemoSiteId());
           setActiveSiteRole('owner');
           setCoordinatorRole('owner');
           setGuests([

--- a/src/pages/dashboard/coordinatorDemoContext.test.ts
+++ b/src/pages/dashboard/coordinatorDemoContext.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCoordinatorDemoSiteId } from './coordinatorDemoContext';
+
+describe('coordinator demo context', () => {
+  it('uses the shared demo wedding site id for coordinator persistence', () => {
+    expect(getCoordinatorDemoSiteId()).toBe('demo-site-id');
+  });
+});

--- a/src/pages/dashboard/coordinatorDemoContext.ts
+++ b/src/pages/dashboard/coordinatorDemoContext.ts
@@ -1,0 +1,5 @@
+import { demoWeddingSite } from '../../lib/demoData';
+
+export function getCoordinatorDemoSiteId() {
+  return demoWeddingSite.id;
+}


### PR DESCRIPTION
## Summary
- Aligns Coordinator Mode demo persistence with the shared Alex/Jordan demo site id.
- Adds a fast regression for the coordinator demo site id helper.
- Logs the proof note and no-deploy status.

## Verification
- `npm test -- src/pages/dashboard/coordinatorDemoContext.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run build`
- `git diff --check`

No deploy was run.
