### PR TITLE
Fix Settings site hydration fields

### DIFF
--- a/src/pages/dashboard/Settings.tsx
+++ b/src/pages/dashboard/Settings.tsx
@@ -17,6 +17,7 @@ import { PLANNER_ROLE_OPTIONS, PLANNER_PERMISSION_GROUPS, getPlannerPermissionPr
 import { resolveActiveSiteForUser } from '../../lib/activeSite';
 import { useToast } from '../../components/ui/Toast';
 import { formatSettingsDate } from './settingsDate';
+import { SETTINGS_SITE_SELECT } from './settingsSiteSelect';
 
 
 interface RSVPQuestionSetting {
@@ -194,7 +195,7 @@ export const DashboardSettings: React.FC = () => {
     try {
       const { data: queryData, error: siteLoadError } = await supabase
         .from('wedding_sites')
-        .select('id, couple_name_1, couple_name_2, active_template_id, site_slug, rsvp_custom_questions, rsvp_meal_config, music_playlist_url')
+        .select(SETTINGS_SITE_SELECT)
         .eq('id', (await resolveActiveSiteForUser(user.id))?.id ?? '')
         .maybeSingle();
       if (siteLoadError) throw siteLoadError;

--- a/src/pages/dashboard/settingsSiteSelect.test.ts
+++ b/src/pages/dashboard/settingsSiteSelect.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { SETTINGS_SITE_SELECT_FIELDS } from './settingsSiteSelect';
+
+describe('settings site select', () => {
+  it('includes every persisted field hydrated by Settings', () => {
+    expect(SETTINGS_SITE_SELECT_FIELDS).toEqual(
+      expect.arrayContaining([
+        'privacy_mode',
+        'hide_from_search',
+        'guest_access_token',
+        'default_language',
+        'notification_prefs',
+        'rsvp_custom_questions',
+        'rsvp_meal_config',
+        'music_playlist_url',
+      ]),
+    );
+  });
+});

--- a/src/pages/dashboard/settingsSiteSelect.ts
+++ b/src/pages/dashboard/settingsSiteSelect.ts
@@ -1,0 +1,17 @@
+export const SETTINGS_SITE_SELECT_FIELDS = [
+  'id',
+  'couple_name_1',
+  'couple_name_2',
+  'active_template_id',
+  'site_slug',
+  'privacy_mode',
+  'hide_from_search',
+  'guest_access_token',
+  'default_language',
+  'notification_prefs',
+  'rsvp_custom_questions',
+  'rsvp_meal_config',
+  'music_playlist_url',
+] as const;
+
+export const SETTINGS_SITE_SELECT = SETTINGS_SITE_SELECT_FIELDS.join(', ');


### PR DESCRIPTION
## Summary
- Restores Settings hydration for saved privacy, language, guest-token, and notification fields.
- Moves the wedding_sites select list into a small tested helper so future Settings state reads cannot silently drift out of the select.

## Verification
- `npm test -- src/pages/dashboard/settingsSiteSelect.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run build`
- `git diff --check`

No deploy was run.
