### PR TITLE
Add branch triage note

### DIFF
--- a/docs/branch-triage-2026-05-25.md
+++ b/docs/branch-triage-2026-05-25.md
@@ -1,0 +1,97 @@
+# Branch Triage - 2026-05-25
+
+This note captures the post-cleanup branch inventory after local/remote branch and worktree pruning.
+
+## Local state
+
+- `main` only
+- no extra worktrees
+- clean and synced with `origin/main`
+
+## Remote survivor map
+
+### Revive carefully
+
+#### `origin/codex/launch-main-p0`
+
+Why keep:
+- only 3 unique commits beyond `origin/main`
+- still carries meaningful launch/auth/RSVP hardening work
+
+Why not treat as PR-ready:
+- overlaps with current `main` in smoke/e2e areas
+- likely better as selective salvage than direct merge
+
+Recommended next move:
+- salvage the desired parts onto a fresh branch from `main`
+
+### Preserve as working history
+
+#### `origin/codex/name-change-form-population-clean`
+
+Why keep:
+- still has 7 unique patch-visible commits
+- coherent name-change form population/runtime line
+
+Why not treat as cleanup residue:
+- not merged
+- not an ancestor of `origin/main`
+- still diverges in real patch content
+
+Recommended next move:
+- preserve as alternate history
+- salvage intentionally if name-change work resumes
+
+#### `origin/codex/non-registry-live-fixes`
+
+Why keep:
+- broad preserved non-registry line
+- large stacked history with product, proof, docs, and CI changes
+
+Recommended next move:
+- leave preserved unless there is explicit product appetite to resurrect pieces
+
+#### `origin/brand-phase-5-imagery-system`
+
+Why keep:
+- real stacked work, not cleanup residue
+- includes focused collaborator/privacy/QR hardening at the tip
+
+Recommended next move:
+- preserve until there is clear product/design appetite to revisit
+
+#### `origin/codex/v1-finish-hard-gates`
+
+Why keep:
+- distinct hardening branch with unique public safety and launch-proof work
+
+Recommended next move:
+- preserve as older hardening history
+
+#### `origin/codex/v1-finish-hard-gates-3`
+
+Why keep:
+- broader later hardening line
+- not safely reducible to `v1-finish-hard-gates`
+
+Recommended next move:
+- preserve as later hardening history
+
+#### `origin/feat/builder-v2-setup-route-skeleton`
+
+Why keep:
+- compact, coherent setup funnel feature
+- focused to four files and six commits
+
+Recommended next move:
+- decide separately whether to revive as a real feature branch
+
+## Summary
+
+Cleanup is complete.
+
+What remains is not hygiene work. The remaining remote branches are preserved product/history lines that need explicit portfolio decisions:
+
+1. salvage and revive
+2. preserve as historical work
+3. retire for product reasons, not cleanup reasons


### PR DESCRIPTION
## Summary
- add a branch triage note documenting the post-cleanup survivor map
- capture which remote branches look revive-worthy vs preserved history
- leave main untouched by switching the working repo back after pushing the note branch

## Note
This is a documentation-only preservation artifact coming out of the cleanup/branch-hygiene pass.