### PR TITLE
Add survivor branch salvage notes

### DIFF
--- a/docs/branch-triage-2026-05-25.md
+++ b/docs/branch-triage-2026-05-25.md
@@ -79,6 +79,7 @@ Why keep:
 
 Recommended next move:
 - preserve as later hardening history
+- see `docs/v1-finish-hard-gates-3-salvage-plan-2026-05-25.md` for the current preservation guidance
 
 #### `origin/feat/builder-v2-setup-route-skeleton`
 

--- a/docs/branch-triage-2026-05-25.md
+++ b/docs/branch-triage-2026-05-25.md
@@ -69,6 +69,7 @@ Why keep:
 
 Recommended next move:
 - preserve as older hardening history
+- see `docs/v1-finish-hard-gates-salvage-plan-2026-05-25.md` for the current preservation guidance
 
 #### `origin/codex/v1-finish-hard-gates-3`
 

--- a/docs/branch-triage-2026-05-25.md
+++ b/docs/branch-triage-2026-05-25.md
@@ -24,6 +24,7 @@ Why not treat as PR-ready:
 
 Recommended next move:
 - salvage the desired parts onto a fresh branch from `main`
+- see `docs/launch-main-p0-salvage-plan-2026-05-25.md` for the current salvage split
 
 ### Preserve as working history
 

--- a/docs/branch-triage-2026-05-25.md
+++ b/docs/branch-triage-2026-05-25.md
@@ -62,6 +62,7 @@ Why keep:
 
 Recommended next move:
 - preserve until there is clear product/design appetite to revisit
+- see `docs/brand-phase-5-imagery-system-salvage-plan-2026-05-25.md` for the current preservation guidance
 
 #### `origin/codex/v1-finish-hard-gates`
 

--- a/docs/branch-triage-2026-05-25.md
+++ b/docs/branch-triage-2026-05-25.md
@@ -87,6 +87,7 @@ Why keep:
 
 Recommended next move:
 - decide separately whether to revive as a real feature branch
+- see `docs/builder-v2-setup-route-skeleton-salvage-plan-2026-05-25.md` for the current revival split
 
 ## Summary
 

--- a/docs/branch-triage-2026-05-25.md
+++ b/docs/branch-triage-2026-05-25.md
@@ -52,6 +52,7 @@ Why keep:
 
 Recommended next move:
 - leave preserved unless there is explicit product appetite to resurrect pieces
+- see `docs/non-registry-live-fixes-salvage-plan-2026-05-25.md` for the current preservation guidance
 
 #### `origin/brand-phase-5-imagery-system`
 

--- a/docs/branch-triage-2026-05-25.md
+++ b/docs/branch-triage-2026-05-25.md
@@ -42,6 +42,7 @@ Why not treat as cleanup residue:
 Recommended next move:
 - preserve as alternate history
 - salvage intentionally if name-change work resumes
+- see `docs/name-change-form-population-salvage-plan-2026-05-25.md` for the current salvage split
 
 #### `origin/codex/non-registry-live-fixes`
 

--- a/docs/brand-phase-5-imagery-system-salvage-plan-2026-05-25.md
+++ b/docs/brand-phase-5-imagery-system-salvage-plan-2026-05-25.md
@@ -1,0 +1,127 @@
+# Brand Phase 5 Imagery System Salvage Plan - 2026-05-25
+
+This note captures the current recommendation for `origin/brand-phase-5-imagery-system`.
+
+## Verdict
+
+Do not delete this branch as cleanup residue.
+
+Also do not treat it as a practical merge branch.
+
+Best next move:
+
+1. preserve it as a mostly-shared history branch with a smaller distinct tip
+2. salvage only the tip-level collaborator, privacy, QR, and deploy-readiness ideas if they are still useful
+3. avoid replaying the full branch as a single feature effort
+
+## Why It Is Worth Preserving
+
+- still has `906` unique patch-visible commits beyond `origin/main`
+- much of its broad history overlaps the same later hardening and extraction era as `origin/codex/non-registry-live-fixes`
+- but it also has a distinct tip-level cluster worth preserving separately
+
+Distinct branch-side tip commits versus `origin/codex/non-registry-live-fixes`:
+
+- `2ff86038a` `fix clean deploy spreadsheet import`
+- `cd062a3c1` `stabilize name-change runtime proof and local deploy gate`
+- `dd7e69fd3` `harden p0 launch gates and live collaborator proofs`
+- `6f6b545d9` `p0 lock down rsvp lookup and enforce production email senders`
+- `ba8f5dd5c` `harden collaborator invites, privacy summary, and qr defaults`
+
+## Why It Is Not A Revival Branch
+
+- merge-base diff against `origin/main` is still enormous and branch-wide history is very mixed
+- most of the branch is not uniquely "imagery system" work anymore
+- the useful distinct value is concentrated near the tip, not across the whole lineage
+- current `main` and the preserved non-registry branches have moved too far for wholesale replay to make sense
+
+Important nuance:
+
+- this branch is best understood as a preserved broad history branch plus a smaller distinct tip
+- that makes it more salvageable than some giant history branches, but only at the tip layer
+
+## Salvage Buckets
+
+### 1. Strongest distinct salvage bucket
+
+Commit:
+
+- `ba8f5dd5c` `harden collaborator invites, privacy summary, and qr defaults`
+
+Touched areas:
+
+- settings dashboard framing
+- team access panel behavior
+- site access actions
+- privacy summary data
+- guest hub QR defaults
+- migration `20260521123000_harden_settings_collaborator_invites.sql`
+
+Why this is attractive:
+
+- compact relative to the rest of the branch
+- clearly distinct from the shared giant-history base
+- focused on current-feeling collaborator/settings concerns
+
+Recommended approach:
+
+- re-read the current settings and collaborator access surfaces on `main`
+- port only the still-desired invite/privacy/QR behaviors
+- treat the migration as a fresh schema review, not a direct replay target
+
+### 2. Medium-confidence hardening bucket
+
+Commits:
+
+- `6f6b545d9` `p0 lock down rsvp lookup and enforce production email senders`
+- `dd7e69fd3` `harden p0 launch gates and live collaborator proofs`
+- `cd062a3c1` `stabilize name-change runtime proof and local deploy gate`
+- `2ff86038a` `fix clean deploy spreadsheet import`
+
+Why these need care:
+
+- they touch deploy, proof, sender, RSVP, collaborator, and import surfaces together
+- they are likely useful as idea sources, but not as clean cherry-pick targets
+
+Recommended approach:
+
+- salvage only one narrow concern at a time
+- prefer re-implementation on fresh `main`
+
+### 3. Shared-history bucket
+
+Everything below the distinct tip overlaps heavily with the same broad hardening and extraction era as `origin/codex/non-registry-live-fixes`.
+
+Recommended approach:
+
+- use the other preservation notes for the big-history interpretation
+- use this branch only when the tip-level collaborator/privacy/QR/deploy angle matters
+
+## Files And Areas Worth Revisiting First
+
+If someone needs to mine this branch, start here:
+
+- `src/pages/dashboard/settings/SettingsTeamAccessPanel.tsx`
+- `src/pages/dashboard/settings/useSettingsSiteAccessActions.ts`
+- `src/pages/dashboard/settings/settingsSiteData.ts`
+- `src/pages/dashboard/settings/SettingsDashboardRouteContent.tsx`
+- `src/lib/guestHubQrAssets.ts`
+- `supabase/functions/_shared/emailSender.ts`
+- `supabase/functions/validate-rsvp-token/index.ts`
+- `supabase/migrations/20260521123000_harden_settings_collaborator_invites.sql`
+
+## Suggested Revival Path
+
+1. create a fresh branch from `main`
+2. decide whether the collaborator invite and privacy-summary changes are still desired
+3. port the smallest useful settings/team-access pieces first
+4. review any sender or RSVP gate hardening as separate follow-up slices
+5. leave the broad shared history preserved instead of replaying it
+
+## Summary
+
+`origin/brand-phase-5-imagery-system` belongs in the "preserve broad history, salvage the distinct tip carefully" bucket.
+
+Preserve the branch.
+Do not merge it directly.
+Use it mainly as a source for the smaller collaborator/privacy/QR/deploy-readiness tip work.

--- a/docs/builder-v2-setup-route-skeleton-salvage-plan-2026-05-25.md
+++ b/docs/builder-v2-setup-route-skeleton-salvage-plan-2026-05-25.md
@@ -1,0 +1,122 @@
+# Builder V2 Setup Route Skeleton Salvage Plan - 2026-05-25
+
+This note captures the current recommendation for `origin/feat/builder-v2-setup-route-skeleton`.
+
+## Verdict
+
+Do not delete this branch as cleanup residue.
+
+Also do not treat it as a direct merge candidate after sitting this long.
+
+Best next move:
+
+1. preserve it as a compact feature seed
+2. revive it from fresh `main` when there is product appetite for the setup funnel
+3. re-implement selectively rather than merging the branch wholesale
+
+## Why It Is Worth Preserving
+
+- only `4` files changed in the merge-base diff
+- only about `402` insertions total
+- the feature scope is coherent: a builder setup funnel for users with no site yet
+- the commit stack tells a clean product story
+
+Branch commits:
+
+1. `82128724b` `feat(builder-v2): add canonical /setup route skeleton and step placeholders`
+2. `ba4ec0c3e` `feat(builder-v2): implement DF-002 names step with local draft persistence`
+3. `afcd507e5` `feat(builder-v2): implement DF-003 wedding date step with undecided option`
+4. `e8ec0242d` `feat(builder-v2): implement DF-004 location step in setup funnel`
+5. `f5a040594` `feat(builder-v2): implement DF-005 guest estimate and DF-006 style/review setup steps`
+6. `f458be7b9` `feat(builder-v2): wire setup draft into builder load and route no-site to /setup`
+
+## Why It Is Not A Straight Merge Candidate
+
+- the branch is old relative to current `main`
+- `main` has moved substantially around builder, dashboard, onboarding, and proof surfaces since this branch was cut
+- a direct branch merge would bring old assumptions along with the feature
+
+Important nuance:
+
+- the branch scope itself is still small and well-bounded
+- this is closer to a "good reimplementation source" than a "dangerous legacy branch"
+
+## Salvage Buckets
+
+### 1. Strongest salvage candidate
+
+Commit:
+
+- `f458be7b9` `feat(builder-v2): wire setup draft into builder load and route no-site to /setup`
+
+Touched file:
+
+- `src/builder/BuilderPage.tsx`
+
+Why this is attractive:
+
+- compact and specific
+- captures the most important route/control-flow idea in the branch
+- likely the best place to start if the setup funnel is revived
+
+Recommended approach:
+
+- reread current `src/builder/BuilderPage.tsx`
+- port only the no-site routing and draft-load ideas that still fit current builder architecture
+
+### 2. Core feature bucket
+
+Files:
+
+- `src/App.tsx`
+- `src/pages/setup/SetupShell.tsx`
+- `src/pages/setup/index.ts`
+
+Why these matter:
+
+- they hold the actual setup-funnel shell and route structure
+- they are small enough to study directly
+- they define the setup product shape more than any deep shared library contract
+
+Recommended approach:
+
+- treat `SetupShell.tsx` as a product prototype, not a drop-in patch
+- re-implement the step flow in current UI patterns when the feature is revived
+
+### 3. Low-risk product concepts worth preserving
+
+The branch still gives good guidance on:
+
+- routing site-less users into an onboarding/setup path
+- collecting names first
+- handling undecided wedding dates
+- collecting location
+- gathering guest estimate
+- capturing style/review inputs before full builder entry
+
+These concepts are more durable than the exact code.
+
+## Files Worth Revisiting First
+
+If someone resumes this branch, start here:
+
+- `src/builder/BuilderPage.tsx`
+- `src/pages/setup/SetupShell.tsx`
+- `src/App.tsx`
+- `src/pages/setup/index.ts`
+
+## Suggested Revival Path
+
+1. create a fresh branch from `main`
+2. decide whether site-less users should still be routed into `/setup`
+3. rebuild the route shell and persistence flow against current builder state
+4. reintroduce setup steps one by one instead of replaying all six historical commits
+5. add modern tests only after the current product shape is settled
+
+## Summary
+
+`origin/feat/builder-v2-setup-route-skeleton` belongs in the "compact feature seed" bucket.
+
+Preserve the branch.
+Do not merge it directly after this much time.
+Use it as a clean source of product intent when the setup funnel is ready to be revived.

--- a/docs/launch-main-p0-salvage-plan-2026-05-25.md
+++ b/docs/launch-main-p0-salvage-plan-2026-05-25.md
@@ -1,0 +1,151 @@
+# Launch Main P0 Salvage Plan - 2026-05-25
+
+This note captures the current recommendation for `origin/codex/launch-main-p0`.
+
+## Verdict
+
+Do not delete this branch as cleanup residue.
+
+Also do not treat it as a low-friction PR branch.
+
+Best next move:
+
+1. start from fresh `main`
+2. salvage the still-desired pieces intentionally
+3. validate each piece against current runtime and proof lanes
+
+## Why It Is Worth Preserving
+
+- only 3 unique commits beyond `origin/main`
+- carries meaningful launch/auth/RSVP hardening
+- includes a small tip commit that looks portable
+
+Branch commits:
+
+1. `abdd07091` `harden launch P0: RSVP, billing gate, sender safety, demo gating`
+2. `05bdd9520` `harden launch proofs and legal links on auth/payment surfaces`
+3. `413f1093f` `fix dashboard/builder site state mismatch for publish visibility`
+
+## Why It Is Not PR-Ready
+
+- total scope is still broad: `32` files changed
+- diff size is still heavy: about `4300` insertions / `1246` deletions
+- launch proof and smoke surfaces overlap with current `main`
+- edge-function behavior would need a fresh live review, not just merge confidence
+
+Known overlap zones:
+
+- `scripts/playwright-owner-create-invite-and-claim.mjs`
+- `tests/e2e/live-smoke.spec.ts`
+- `tests/e2e/collaborator-permission-rls.spec.ts`
+
+## Salvage Buckets
+
+### 1. Strongest salvage candidate
+
+Commit:
+
+- `413f1093f` `fix dashboard/builder site state mismatch for publish visibility`
+
+Touched files:
+
+- `src/components/dashboard/DashboardLayout.tsx`
+- `src/pages/dashboard/Overview.tsx`
+
+Why this is attractive:
+
+- compact
+- product-facing
+- easier to re-implement on top of current `main`
+
+Recommended approach:
+
+- re-read the current `main` versions of those two files
+- port only the publish-visibility/site-state fix
+- add a narrow regression test if the current surface supports one
+
+### 2. Medium-confidence salvage candidate
+
+Commit:
+
+- `05bdd9520` `harden launch proofs and legal links on auth/payment surfaces`
+
+Touched files:
+
+- `scripts/rsvp_smoke.js`
+- `scripts/site_lookup_smoke.js`
+- `src/pages/Login.tsx`
+- `src/pages/PaymentRequired.tsx`
+- `src/pages/Signup.tsx`
+- `tests/e2e/live-smoke.spec.ts`
+
+Why this needs care:
+
+- part runtime wording
+- part smoke expectation drift
+- part auth/legal link surface
+
+Recommended approach:
+
+- split UI/legal-link changes from smoke-script changes
+- keep only wording or link-hardening that still matches the shipped product
+- treat `tests/e2e/live-smoke.spec.ts` as a fresh rewrite target, not a cherry-pick target
+
+### 3. Large salvage bucket
+
+Commit:
+
+- `abdd07091` `harden launch P0: RSVP, billing gate, sender safety, demo gating`
+
+Touched areas:
+
+- auth gating
+- home/product surfaces
+- RSVP/session validation
+- email and SMS edge functions
+- collaborator permissions
+- live smoke and collaborator RLS proof coverage
+- deployment/env guidance
+
+Why this should not be transplanted wholesale:
+
+- too many behavior surfaces moved together
+- includes edge-function contract changes
+- includes proof/test/docs changes mixed with product logic
+- likely contains pieces already solved differently on `main`
+
+Recommended approach:
+
+- mine this commit for specific ideas, not direct patch application
+- if revived, split into separate work items:
+  - auth/payment gate behavior
+  - RSVP/session validation behavior
+  - sender safety / messaging edge-function behavior
+  - collaborator permission proof coverage
+
+## Files Worth Revisiting First
+
+If someone resumes this branch, start here:
+
+- `src/components/dashboard/DashboardLayout.tsx`
+- `src/pages/dashboard/Overview.tsx`
+- `src/components/auth/ProtectedRoute.tsx`
+- `supabase/functions/validate-rsvp-token/index.ts`
+- `supabase/functions/_shared/emailSender.ts`
+- `tests/e2e/live-smoke.spec.ts`
+
+## Suggested Revival Path
+
+1. create a fresh branch from `main`
+2. re-implement the dashboard publish-visibility fix from `413f1093f`
+3. decide whether auth/legal-link wording from `05bdd9520` still matters
+4. open separate follow-up tickets for any surviving pieces from `abdd07091`
+5. ignore the idea of merging `origin/codex/launch-main-p0` directly
+
+## Summary
+
+`origin/codex/launch-main-p0` belongs in the "careful salvage" bucket.
+
+Preserve the branch.
+Do not merge it directly.
+Use it as a source branch for small, current, intentional follow-up work.

--- a/docs/name-change-form-population-salvage-plan-2026-05-25.md
+++ b/docs/name-change-form-population-salvage-plan-2026-05-25.md
@@ -1,0 +1,152 @@
+# Name Change Form Population Salvage Plan - 2026-05-25
+
+This note captures the current recommendation for `origin/codex/name-change-form-population-clean`.
+
+## Verdict
+
+Do not delete this branch as cleanup residue.
+
+Also do not treat it as a clean PR branch.
+
+Best next move:
+
+1. preserve it as alternate history
+2. salvage the core pipeline intentionally if name-change work resumes
+3. avoid treating the later hardpass and smoke commits as the main value of the branch
+
+## Why It Is Worth Preserving
+
+- still has `7` unique patch-visible commits beyond `origin/main`
+- contains a substantial name-change form population pipeline
+- includes a large scripts-and-library buildout that was never reduced to small current slices
+
+Branch commits:
+
+1. `b3dec0bc8` `integrate name change form population pipeline`
+2. `f93c8b13a` `align name change form population tests`
+3. `c93a421fc` `fix pr type gate for name change integration`
+4. `d0e898998` `fix hardpass drift for name change integration`
+5. `8ab3a9273` `stabilize hardpass date expectations`
+6. `e284967b5` `support rsvp session smoke contract`
+7. `af4def680` `accept not-found RSVP invalid token blocks`
+
+## Why It Is Not PR-Ready
+
+- total branch surface is still broad: `119` files in the merge-base diff
+- the core pipeline commit alone is enormous
+- much of the later branch stack is test/CI/hardpass alignment wrapped around the main pipeline
+- the branch overlaps heavily with current `main`, so a direct merge would be high-noise and low-confidence
+
+Important nuance:
+
+- `scripts/rsvp_smoke.js` is currently identical on `origin/main` and on this branch
+- that means the last two RSVP smoke commits still matter historically, but they are not a current code delta to salvage directly
+
+## Salvage Buckets
+
+### 1. Core salvage candidate
+
+Commit:
+
+- `b3dec0bc8` `integrate name change form population pipeline`
+
+Why this is the real value:
+
+- it contains the actual product and workflow investment
+- it introduces the bulk of the name-change scripts and `src/lib/nameChange/*` machinery
+- it is the part most likely to matter if the feature is revived
+
+High-value areas inside that commit:
+
+- script pipeline for answer intake, draft output, review bundles, PDF adapter catalogs, FDF export, and runtime proofing
+- `src/lib/nameChange/formPopulationPlan.ts`
+- `src/lib/nameChange/formPopulationDraft.ts`
+- `src/lib/nameChange/formPopulationIntakeAnswerApply.ts`
+- `src/lib/nameChange/formPopulationIntakeAnswerResponse.ts`
+- `src/lib/nameChange/formPdfAdapterTemplate.ts`
+- `src/lib/nameChange/formPdfReviewPacket.ts`
+- `src/lib/nameChange/formCompanion.ts`
+- `src/lib/nameChange/formDraftReadiness.ts`
+
+Recommended approach:
+
+- treat this commit as a source archive, not a cherry-pick candidate
+- if revived, split the pipeline into smaller current slices:
+  - core library primitives
+  - script entrypoints
+  - planning/dashboard integration
+  - proof/runtime validation
+
+### 2. Integration and follow-up bucket
+
+Commit:
+
+- `c93a421fc` `fix pr type gate for name change integration`
+
+Why this needs care:
+
+- it mixes name-change integration with broader dashboard/planning and builder surfaces
+- it also pulls in unrelated-looking helper/test adjustments
+
+Files worth rereading if revival happens:
+
+- `src/pages/dashboard/planning/usePlanningDashboardActions.ts`
+- `src/pages/dashboard/planning/vendorMetaStorage.ts`
+- `src/pages/dashboard/planning/nameChangeService.ts`
+- `src/lib/nameChange/types.ts`
+
+Recommended approach:
+
+- salvage only the pieces that are clearly required by the current name-change user flow
+- do not port the whole commit as a unit
+
+### 3. Test and hardpass follow-up bucket
+
+Commits:
+
+- `f93c8b13a`
+- `d0e898998`
+- `8ab3a9273`
+- `e284967b5`
+- `af4def680`
+
+Why these are secondary:
+
+- they mostly stabilize expectations around the main pipeline work
+- they are valuable as evidence of what hurt during integration
+- they are poor anchors for a new implementation because current `main` has moved on
+
+Recommended approach:
+
+- use them as review notes after reviving core functionality
+- do not start by replaying them
+
+## Files Worth Revisiting First
+
+If someone resumes this branch, start here:
+
+- `src/lib/nameChange/formPopulationPlan.ts`
+- `src/lib/nameChange/formPopulationDraft.ts`
+- `src/lib/nameChange/formPopulationIntakeAnswerApply.ts`
+- `src/lib/nameChange/formPopulationIntakeAnswerResponse.ts`
+- `src/lib/nameChange/formPdfAdapterTemplate.ts`
+- `src/lib/nameChange/formPdfReviewPacket.ts`
+- `src/lib/nameChange/formCompanion.ts`
+- `src/pages/dashboard/planning/nameChangeService.ts`
+- `src/pages/dashboard/planning/usePlanningDashboardActions.ts`
+
+## Suggested Revival Path
+
+1. create a fresh branch from `main`
+2. identify the smallest useful subset of the core name-change pipeline
+3. reintroduce library primitives before script wrappers
+4. reconnect planning/dashboard surfaces only after the core pipeline shape is proven
+5. revisit hardpass and smoke expectations at the end, not the beginning
+
+## Summary
+
+`origin/codex/name-change-form-population-clean` belongs in the "preserve and salvage deliberately" bucket.
+
+Preserve the branch.
+Do not merge it directly.
+Use it as a historical source for a future, much smaller name-change revival.

--- a/docs/non-registry-live-fixes-salvage-plan-2026-05-25.md
+++ b/docs/non-registry-live-fixes-salvage-plan-2026-05-25.md
@@ -1,0 +1,124 @@
+# Non Registry Live Fixes Salvage Plan - 2026-05-25
+
+This note captures the current recommendation for `origin/codex/non-registry-live-fixes`.
+
+## Verdict
+
+Do not delete this branch as cleanup residue.
+
+Also do not treat it as a practical merge or revival branch.
+
+Best next move:
+
+1. preserve it as a broad non-registry hardening and extraction history branch
+2. mine it for narrow patterns or targeted ideas only when needed
+3. avoid replaying it as one giant rescue effort
+
+## Why It Is Worth Preserving
+
+- still has `906` unique patch-visible commits beyond `origin/main`
+- contains the later `hard-gates` history plus an even broader non-registry extraction wave
+- captures a lot of product-facing decomposition and live-fix reasoning that may still be useful as reference
+
+Representative themes:
+
+- public, RSVP, guest, vault, messaging, and settings safety tightening
+- bounded reads and capped fan-out across dashboard and guest surfaces
+- major service extraction across auth, itinerary, guest dashboards, guest photo, vault, RSVP, and messaging
+- route-view and shell decomposition for dashboard and public flows
+- live proof narrowing and collaborator/public authorization proof updates
+- coordinator, seating, planning, name-change, and media write-path evolution
+
+## Why It Is Not A Revival Branch
+
+- merge-base diff is enormous: about `3749` files
+- rough diff size is massive: about `304284` insertions / `44822` deletions
+- the branch mixes too many layers of change together:
+  - hardening and safety
+  - service extraction and architectural decomposition
+  - route/view/component extraction
+  - schema and RPC evolution
+  - proof, docs, and launch-history context
+- current `main` has moved far enough that direct resurrection would be all archaeology and almost no clean momentum
+
+Important nuance:
+
+- this branch is not just "old fixes"
+- it is a historical snapshot of how a huge amount of non-registry product surface was being broken apart and hardened at once
+- that makes it useful for patterns, but almost impossible to merge or revive wholesale
+
+## Salvage Buckets
+
+### 1. Service and route decomposition bucket
+
+This branch is especially useful for studying:
+
+- guest dashboard route/view extraction
+- settings panel and dashboard shell extraction
+- RSVP flow shell and view extraction
+- event hub, event recap, and public-route shell decomposition
+- auth/service helper extraction
+- itinerary, planning, guest photo, and vault service boundaries
+
+Recommended approach:
+
+- if a current module is too large or too entangled, inspect the matching extraction here for ideas
+- port patterns, not patches
+
+### 2. Narrow live-fix and safety bucket
+
+The branch also contains many smaller hardening ideas:
+
+- bounded reads and fan-out controls
+- public and preview copy/contract tightening
+- guest contact lookup, RSVP lookup, and helper-copy hardening
+- public registry and client safety refinements
+- collaborator and service-role proof narrowing
+
+Recommended approach:
+
+- use this branch when a current bug or safety issue resembles one of those themes
+- re-implement only the narrow current fix on top of `main`
+
+### 3. Proof and operating-history bucket
+
+Like the hard-gates branches, this one also contains:
+
+- production hardening docs
+- launch and audit notes
+- proof captures and residual review context
+
+Recommended approach:
+
+- treat these as operating history
+- use them to understand why certain live-fix or safety decisions were made
+
+## Files And Areas Worth Revisiting First
+
+If someone needs to mine this branch, start with the closest matching surface:
+
+- guest dashboard route and workspace shell files
+- settings dashboard shell and extracted settings panels
+- RSVP flow shell and live content views
+- event hub and event recap extracted live-content files
+- bounded read helpers and service extraction files around the exact failing area
+
+## Suggested Revival Path
+
+This branch should not be revived as a branch.
+
+If work must be resumed from it:
+
+1. identify one narrow current problem or one oversized current surface
+2. find the matching extraction or hardening theme here
+3. re-implement that idea in a fresh focused branch from `main`
+4. validate it with current tests and proof flows
+5. leave the rest of this branch preserved as history
+
+## Summary
+
+`origin/codex/non-registry-live-fixes` belongs in the "preserve as broad non-registry hardening and extraction history" bucket.
+
+Preserve the branch.
+Do not merge it directly.
+Use it as a historical source for narrow hardening ideas and decomposition patterns only.

--- a/docs/v1-finish-hard-gates-3-salvage-plan-2026-05-25.md
+++ b/docs/v1-finish-hard-gates-3-salvage-plan-2026-05-25.md
@@ -1,0 +1,125 @@
+# V1 Finish Hard Gates 3 Salvage Plan - 2026-05-25
+
+This note captures the current recommendation for `origin/codex/v1-finish-hard-gates-3`.
+
+## Verdict
+
+Do not delete this branch as cleanup residue.
+
+Also do not treat it as a practical merge or revival branch.
+
+Best next move:
+
+1. preserve it as a major hardening-and-extraction history branch
+2. mine it for narrow patterns when needed
+3. avoid replaying it as a single resurrection effort
+
+## Why It Is Worth Preserving
+
+- still has `879` unique patch-visible commits beyond `origin/main`
+- captures a major later hardening line after the earlier `v1-finish-hard-gates` branch
+- contains both:
+  - launch/public safety tightening
+  - a broad wave of service extraction and route/view decomposition
+
+Representative themes:
+
+- public, RSVP, vault, and registry safety tightening
+- bounded query fan-out and dashboard read limits
+- auth/session/helper service extraction
+- guest dashboard extraction into services, panels, overlays, and route views
+- settings/dashboard shell extraction
+- live proof narrowing and collaborator authorization proof updates
+- coordinator, messaging, seating, guest-photo, and planning service decomposition
+
+## Why It Is Not A Revival Branch
+
+- merge-base diff is enormous: about `2734` files
+- rough diff size is massive: about `221349` insertions / `41494` deletions
+- this branch mixes at least four different classes of work:
+  - hardening and safety
+  - architectural extraction/refactoring
+  - proof and launch-history artifacts
+  - schema and RPC evolution
+- current `main` has moved far beyond the point where replaying this branch as a unit would make sense
+
+Important nuance:
+
+- unlike `v1-finish-hard-gates`, this branch is not only a hardening-history branch
+- it is also a historical snapshot of a very large decomposition effort
+- that makes it valuable for ideas and patterns, but even worse as a direct merge target
+
+## Salvage Buckets
+
+### 1. Service-boundary pattern bucket
+
+This branch is especially useful for studying extraction patterns such as:
+
+- auth service extraction
+- guest dashboard route/view decomposition
+- message and itinerary service extraction
+- settings panel extraction
+- vault and guest photo function transport extraction
+
+Recommended approach:
+
+- if a current file feels too large or too entangled, inspect the matching extraction here for ideas
+- port patterns, not patches
+
+### 2. Narrow safety-and-bounds bucket
+
+The branch also contains many focused hardening ideas:
+
+- bounded dashboard and workspace reads
+- query fan-out caps
+- public/client safety tightening
+- collaborator and service-role proof narrowing
+
+Recommended approach:
+
+- use this branch when a current performance or safety issue matches one of those themes
+- re-implement only the narrow fix needed on top of current `main`
+
+### 3. Proof and launch-history bucket
+
+Like the older hard-gates branch, this one also includes:
+
+- proof screenshots
+- production hardening docs
+- launch and audit notes
+- residual audit/history context
+
+Recommended approach:
+
+- treat these as historical reference only
+- use them to explain why earlier protections or refactors happened
+
+## Files And Areas Worth Revisiting First
+
+If someone needs to mine this branch, start with the closest matching surface:
+
+- guest dashboard route/service files
+- settings dashboard shell and panel extraction files
+- auth service extraction files
+- bounded query or dashboard read helpers
+- collaborator proof and public safety surfaces
+
+## Suggested Revival Path
+
+This branch should not be revived as a branch.
+
+If work must be resumed from it:
+
+1. identify one current problem or one oversized current module
+2. find the matching extraction or hardening theme in this branch
+3. re-implement that idea in a fresh focused branch from `main`
+4. validate it with current tests and proof flows
+5. leave the rest of this branch preserved as history
+
+## Summary
+
+`origin/codex/v1-finish-hard-gates-3` belongs in the "preserve as major hardening and extraction history" bucket.
+
+Preserve the branch.
+Do not merge it directly.
+Use it as a historical source for narrow hardening ideas and service-boundary patterns only.

--- a/docs/v1-finish-hard-gates-salvage-plan-2026-05-25.md
+++ b/docs/v1-finish-hard-gates-salvage-plan-2026-05-25.md
@@ -1,0 +1,135 @@
+# V1 Finish Hard Gates Salvage Plan - 2026-05-25
+
+This note captures the current recommendation for `origin/codex/v1-finish-hard-gates`.
+
+## Verdict
+
+Do not delete this branch as cleanup residue.
+
+Also do not treat it as a realistic merge candidate anymore.
+
+Best next move:
+
+1. preserve it as a hardening-history branch
+2. mine it for narrow security and validation ideas only when needed
+3. avoid broad resurrection work unless there is a very explicit launch-hardening project
+
+## Why It Is Worth Preserving
+
+- still has `29` unique patch-visible commits beyond `origin/main`
+- captures a coherent hardening era focused on public safety, RSVP/public gates, registry preview safety, and launch-proof work
+- contains a lot of deploy-proof and verification context that explains why later protections were added
+
+Representative commit themes:
+
+- launch hardening and production proof
+- public and RSVP gate hardening
+- registry preview image proxying and image sanitization
+- public link host and QR URL hardening
+- vendor inquiry and shared email CTA safety
+- Stripe return URL hardening
+- client error log redaction
+- photo upload and guest email validation tightening
+
+## Why It Is Not A Revival Branch
+
+- merge-base diff is enormous: about `2211` files
+- rough diff size is massive: about `131490` insertions / `26129` deletions
+- branch contains a large mixture of:
+  - code changes
+  - workflow changes
+  - migration changes
+  - proof screenshots
+  - backlog/docs/history artifacts
+- current `main` has moved far enough that direct resurrection would create more archaeology than progress
+
+Important nuance:
+
+- this branch is still valuable as a source of hardening patterns
+- it is not valuable as a single unit of work to replay
+
+## Salvage Buckets
+
+### 1. Narrow security-pattern bucket
+
+These are the kinds of changes most worth mining:
+
+- public link host guards
+- QR URL hardening
+- vendor inquiry email validation
+- shared CTA URL validation
+- Stripe checkout return URL safety
+- client error log redaction
+- registry preview image sanitization
+
+Recommended approach:
+
+- if one of these surfaces regresses or needs extension, inspect the relevant commit and re-implement the idea on top of current `main`
+- do not cherry-pick broad commit ranges
+
+### 2. Proof and launch-history bucket
+
+The branch also contains a lot of proof-era artifacts:
+
+- launch proof docs
+- backlog snapshots
+- screenshot captures
+- runbook-like historical context
+
+Why this matters:
+
+- it helps explain the launch-hardening sequence
+- it is useful for forensic context
+- it should not drive current product architecture directly
+
+Recommended approach:
+
+- treat these materials as historical evidence
+- use them to answer "why was this tightened?" questions, not "what should we merge?" questions
+
+### 3. Large mixed hardening bucket
+
+The oldest and biggest commits mix too many concerns together:
+
+- auth/public gate behavior
+- registry safety
+- vendor/public inquiry safety
+- proof expectations
+- docs and launch-history notes
+
+Recommended approach:
+
+- only extract tiny, current needs
+- create fresh focused patches on `main`
+- never try to replay the branch as a bundle
+
+## Files And Areas Worth Revisiting First
+
+If someone needs to mine this branch, start with the surface closest to the problem at hand:
+
+- `src/sections/publicLinks.ts`
+- registry preview/image safety files
+- vendor inquiry and public email validation surfaces
+- Stripe return URL handling
+- error-log redaction surfaces
+- the matching focused e2e or proof scripts around that exact area
+
+## Suggested Revival Path
+
+This branch should almost never be "revived" directly.
+
+If work must be resumed:
+
+1. identify one narrow current problem
+2. find the matching historical hardening commit/theme here
+3. re-implement only that idea on fresh `main`
+4. validate it with current tests and proof scripts
+5. leave the rest of the branch preserved as history
+
+## Summary
+
+`origin/codex/v1-finish-hard-gates` belongs in the "preserve as hardening history" bucket.
+
+Preserve the branch.
+Do not merge it directly.
+Use it as a historical source for targeted hardening ideas only.


### PR DESCRIPTION
## Summary
- add focused salvage notes for brand-phase-5-imagery-system, launch-main-p0, name-change-form-population-clean, builder-v2 setup route skeleton, v1-finish-hard-gates, v1-finish-hard-gates-3, and non-registry-live-fixes
- link the branch triage note to each deeper salvage or preservation note
- capture which survivor branches are worth selective revival, which are better treated as feature seeds, and which should remain hardening, extraction, or operating history

## Testing
- git diff --check -- docs/branch-triage-2026-05-25.md docs/brand-phase-5-imagery-system-salvage-plan-2026-05-25.md docs/launch-main-p0-salvage-plan-2026-05-25.md docs/name-change-form-population-salvage-plan-2026-05-25.md docs/builder-v2-setup-route-skeleton-salvage-plan-2026-05-25.md docs/v1-finish-hard-gates-salvage-plan-2026-05-25.md docs/v1-finish-hard-gates-3-salvage-plan-2026-05-25.md docs/non-registry-live-fixes-salvage-plan-2026-05-25.md