### PR TITLE
Preserve dashboard site privacy mode

### DIFF
--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -3,10 +3,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import {
   Heart,
   LayoutDashboard,
-  Palette,
   Users,
   Image,
-  Camera,
   Gift,
   Settings,
   Menu,
@@ -33,6 +31,7 @@ import { resolveActiveSiteForUser, resolveActiveSiteRoleForUser } from '../../li
 import { getStoredActiveSiteId, setStoredActiveSiteId } from '../../lib/activeSiteStorage';
 import { getDemoDashboardSiteContext } from './dashboardDemoContext';
 import { buildSiteMembershipLabel } from './siteMembershipLabel';
+import { resolveDashboardLayoutSiteContext } from './dashboardSiteContext';
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -131,24 +130,26 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, curr
 
       const { data } = await supabase
         .from('wedding_sites')
-        .select('id, site_slug, site_url, site_json, is_published')
+        .select('id, site_slug, site_url, site_json, is_published, privacy_mode')
         .eq('id', targetSiteId)
         .maybeSingle();
 
       const row = (data as Record<string, unknown> | null) ?? null;
+      const siteContext = resolveDashboardLayoutSiteContext(row);
       const resolved = resolvePublicSiteSlugFromRow(row);
       if (resolved) setSiteSlug(resolved);
-      if (row?.id && typeof row.id === 'string') setSiteId(row.id);
-      setSiteIsPublished(row?.is_published === true);
+      if (siteContext.rowId) setSiteId(siteContext.rowId);
+      setSiteIsPublished(siteContext.isPublished);
+      setSitePrivacyMode(siteContext.privacyMode);
 
-      const siteJson = row?.site_json;
-      if (siteJson && typeof siteJson === 'object' && !Array.isArray(siteJson)) {
-        const parsedSiteJson = siteJson as Record<string, unknown>;
-        setSiteJsonState(parsedSiteJson);
-        const dashboard = parsedSiteJson.dashboard;
+      if (siteContext.siteJson) {
+        setSiteJsonState(siteContext.siteJson);
+        const dashboard = siteContext.siteJson.dashboard;
         if (dashboard && typeof dashboard === 'object' && !Array.isArray(dashboard)) {
           // legacy sidebar feature state ignored after nav rollup
         }
+      } else {
+        setSiteJsonState(null);
       }
     };
 

--- a/src/components/dashboard/dashboardSiteContext.test.ts
+++ b/src/components/dashboard/dashboardSiteContext.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDashboardLayoutSiteContext } from './dashboardSiteContext';
+
+describe('resolveDashboardLayoutSiteContext', () => {
+  it('preserves private live visibility modes from the site row', () => {
+    const result = resolveDashboardLayoutSiteContext({
+      id: 'site-123',
+      is_published: true,
+      privacy_mode: 'invite_only',
+      site_json: { hide_from_search: true },
+    });
+
+    expect(result).toMatchObject({
+      rowId: 'site-123',
+      isPublished: true,
+      privacyMode: 'invite_only',
+      siteJson: { hide_from_search: true },
+    });
+  });
+
+  it('falls back to public when privacy mode is missing or invalid', () => {
+    expect(
+      resolveDashboardLayoutSiteContext({
+        id: 'site-123',
+        is_published: true,
+        privacy_mode: 'something-else',
+        site_json: null,
+      }).privacyMode,
+    ).toBe('public');
+
+    expect(resolveDashboardLayoutSiteContext(null).privacyMode).toBe('public');
+  });
+});

--- a/src/components/dashboard/dashboardSiteContext.ts
+++ b/src/components/dashboard/dashboardSiteContext.ts
@@ -1,0 +1,22 @@
+export type DashboardLayoutSiteContext = {
+  rowId: string | null;
+  siteJson: Record<string, unknown> | null;
+  isPublished: boolean;
+  privacyMode: 'public' | 'password_protected' | 'invite_only';
+};
+
+export function resolveDashboardLayoutSiteContext(row: Record<string, unknown> | null): DashboardLayoutSiteContext {
+  const siteJson = row?.site_json;
+  return {
+    rowId: row?.id && typeof row.id === 'string' ? row.id : null,
+    siteJson:
+      siteJson && typeof siteJson === 'object' && !Array.isArray(siteJson)
+        ? (siteJson as Record<string, unknown>)
+        : null,
+    isPublished: row?.is_published === true,
+    privacyMode:
+      row?.privacy_mode === 'password_protected' || row?.privacy_mode === 'invite_only'
+        ? row.privacy_mode
+        : 'public',
+  };
+}


### PR DESCRIPTION
## Summary
- preserve the dashboard site visibility state by loading `privacy_mode` in `DashboardLayout`
- normalize dashboard site rows through a tiny helper so private live states do not collapse back to public
- add a focused test for the dashboard site-context normalization

## Testing
- npm test -- --run src/components/dashboard/dashboardSiteContext.test.ts
- npx eslint src/components/dashboard/DashboardLayout.tsx src/components/dashboard/dashboardSiteContext.ts src/components/dashboard/dashboardSiteContext.test.ts
- git diff --check -- src/components/dashboard/DashboardLayout.tsx src/components/dashboard/dashboardSiteContext.ts src/components/dashboard/dashboardSiteContext.test.ts