### PR TITLE
Add auth support footer links

### DIFF
--- a/src/components/auth/AuthSupportLinks.test.tsx
+++ b/src/components/auth/AuthSupportLinks.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+import { AuthSupportLinks } from './AuthSupportLinks';
+
+describe('AuthSupportLinks', () => {
+  it('renders the support, legal, and refund links used on auth-adjacent pages', () => {
+    render(<AuthSupportLinks />);
+
+    expect(screen.getByRole('link', { name: 'Support' })).toHaveAttribute('href', '/support');
+    expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute('href', '/privacy');
+    expect(screen.getByRole('link', { name: 'Terms' })).toHaveAttribute('href', '/terms');
+    expect(screen.getByRole('link', { name: 'Refund' })).toHaveAttribute('href', '/refund');
+  });
+});

--- a/src/components/auth/AuthSupportLinks.tsx
+++ b/src/components/auth/AuthSupportLinks.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const SUPPORT_LINKS = [
+  { href: '/support', label: 'Support' },
+  { href: '/privacy', label: 'Privacy' },
+  { href: '/terms', label: 'Terms' },
+  { href: '/refund', label: 'Refund' },
+] as const;
+
+export const AuthSupportLinks: React.FC = () => (
+  <div className="mt-4 flex flex-wrap items-center justify-center gap-4 text-xs text-text-tertiary">
+    {SUPPORT_LINKS.map((item) => (
+      <Link key={item.href} to={item.href} className="hover:text-text-primary transition-colors">
+        {item.label}
+      </Link>
+    ))}
+  </div>
+);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { Heart, Chrome, ArrowLeft, Mail, AlertCircle } from 'lucide-react';
 import { Button, Card, Input } from '../components/ui';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../hooks/useAuth';
+import { AuthSupportLinks } from '../components/auth/AuthSupportLinks';
 import { consumeSignupReturnPath, writeSignupReturnPath } from '../lib/signupContinuation';
 import { clearAuthEntryReturnPath } from '../lib/authEntryCleanup';
 import { resolveLoginReturnPath } from '../lib/loginReturnResolver';
@@ -420,6 +421,7 @@ export const Login: React.FC = () => {
               </Link>
             </p>
           </div>
+          <AuthSupportLinks />
         </Card>
       </div>
     </div>

--- a/src/pages/PaymentRequired.tsx
+++ b/src/pages/PaymentRequired.tsx
@@ -4,10 +4,9 @@ import { Heart, CreditCard, Check, Loader2, AlertCircle, RefreshCw } from 'lucid
 import { Button } from '../components/ui';
 import { useAuth } from '../hooks/useAuth';
 import { supabase } from '../lib/supabase';
+import { AuthSupportLinks } from '../components/auth/AuthSupportLinks';
 import { createCheckoutSession, fetchPaymentStatus, fetchWeddingSiteId, SessionExpiredError } from '../lib/stripeService';
-import { isPaymentGateEnabled } from '../lib/paymentGate';
 import { clearAllOnboardingContinuationState } from '../lib/onboardingContinuationCleanup';
-import { buildQuickStartEntryPath } from '../lib/quickStartContinuation';
 
 const FEATURES = [
   'Your own wedding website with custom URL',
@@ -58,7 +57,6 @@ const ensureMinimalWeddingSite = async (userId: string, email?: string | null): 
 
 export const PaymentRequired: React.FC = () => {
   const { user } = useAuth();
-  const paymentGateEnabled = isPaymentGateEnabled();
   const paymentBypassAllowed = true;
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -253,6 +251,7 @@ export const PaymentRequired: React.FC = () => {
             <p className="text-xs text-text-tertiary text-center">
               Secure payment powered by Stripe. We never store your card details.
             </p>
+            <AuthSupportLinks />
           </div>
         </div>
       </div>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -3,11 +3,11 @@ import { Link, useLocation, useNavigate, useSearchParams, createSearchParams } f
 import { Chrome, Heart } from 'lucide-react';
 import { Button, Card, Input } from '../components/ui';
 import { supabase } from '../lib/supabase';
+import { AuthSupportLinks } from '../components/auth/AuthSupportLinks';
 import { isPaymentGateEnabled } from '../lib/paymentGate';
 import { consumeSignupReturnPath, writeSignupReturnPath } from '../lib/signupContinuation';
 import { clearAuthEntryReturnPath } from '../lib/authEntryCleanup';
 import { resolveSignupReturnPath } from '../lib/signupReturnResolver';
-import { buildQuickStartEntryPath } from '../lib/quickStartContinuation';
 import { normalizeMeaningfulQuickStartDraftSnapshot, persistQuickStartDraftSnapshot } from '../lib/quickStartStateTransfer';
 
 const makeBaseSlug = (email: string) => {
@@ -313,6 +313,7 @@ export const Signup: React.FC = () => {
               </button>
             </p>
           </div>
+          <AuthSupportLinks />
         </Card>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a shared auth support footer with support, privacy, terms, and refund links
- use it on login, signup, and payment-required flows instead of repeating local link markup
- add a focused component test for the shared link set

## Testing
- npm test -- --run src/components/auth/AuthSupportLinks.test.tsx
- npx eslint src/components/auth/AuthSupportLinks.tsx src/components/auth/AuthSupportLinks.test.tsx src/pages/Login.tsx src/pages/Signup.tsx src/pages/PaymentRequired.tsx
- git diff --check -- src/components/auth/AuthSupportLinks.tsx src/components/auth/AuthSupportLinks.test.tsx src/pages/Login.tsx src/pages/Signup.tsx src/pages/PaymentRequired.tsx