### PR TITLE
Load smoke env from .env and .env.local

### DIFF
--- a/scripts/rsvp_smoke.js
+++ b/scripts/rsvp_smoke.js
@@ -1,26 +1,6 @@
-import fs from 'node:fs';
+import { loadSmokeEnv, normalizeEnvValue } from './smokeEnv.mjs';
 
-const normalizeEnvValue = (value) => {
-  if (typeof value !== 'string') return '';
-  const trimmed = value.trim().replace(/[\r\n]+/g, '').replace(/\\n/g, '').replace(/\\r/g, '');
-  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
-    return trimmed.slice(1, -1).trim();
-  }
-  return trimmed;
-};
-
-const fileEnv = fs.existsSync('.env.local')
-  ? Object.fromEntries(
-      fs.readFileSync('.env.local', 'utf8')
-        .split('\n')
-        .map((l) => l.trim())
-        .filter((line) => line && !line.startsWith('#') && line.includes('='))
-        .map((line) => {
-          const i = line.indexOf('=');
-          return [line.slice(0, i), normalizeEnvValue(line.slice(i + 1))];
-        })
-    )
-  : {};
+const fileEnv = loadSmokeEnv();
 
 const base = normalizeEnvValue(process.env.VITE_SUPABASE_URL || fileEnv.VITE_SUPABASE_URL);
 const key = normalizeEnvValue(process.env.VITE_SUPABASE_ANON_KEY || fileEnv.VITE_SUPABASE_ANON_KEY);

--- a/scripts/site_lookup_smoke.js
+++ b/scripts/site_lookup_smoke.js
@@ -1,26 +1,6 @@
-import fs from 'node:fs';
+import { loadSmokeEnv, normalizeEnvValue } from './smokeEnv.mjs';
 
-const normalizeEnvValue = (value) => {
-  if (typeof value !== 'string') return '';
-  const trimmed = value.trim().replace(/[\r\n]+/g, '').replace(/\\n/g, '').replace(/\\r/g, '');
-  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
-    return trimmed.slice(1, -1).trim();
-  }
-  return trimmed;
-};
-
-const fileEnv = fs.existsSync('.env.local')
-  ? Object.fromEntries(
-      fs.readFileSync('.env.local', 'utf8')
-        .split('\n')
-        .map((l) => l.trim())
-        .filter((line) => line && !line.startsWith('#') && line.includes('='))
-        .map((line) => {
-          const i = line.indexOf('=');
-          return [line.slice(0, i), normalizeEnvValue(line.slice(i + 1))];
-        })
-    )
-  : {};
+const fileEnv = loadSmokeEnv();
 
 const base = normalizeEnvValue(process.env.VITE_SUPABASE_URL || fileEnv.VITE_SUPABASE_URL);
 const key = normalizeEnvValue(process.env.VITE_SUPABASE_ANON_KEY || fileEnv.VITE_SUPABASE_ANON_KEY);

--- a/scripts/smokeEnv.mjs
+++ b/scripts/smokeEnv.mjs
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+
+export const normalizeEnvValue = (value) => {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim().replace(/[\r\n]+/g, '').replace(/\\n/g, '').replace(/\\r/g, '');
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+};
+
+export const loadEnvFile = (path) => (fs.existsSync(path)
+  ? Object.fromEntries(
+      fs.readFileSync(path, 'utf8')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith('#') && line.includes('='))
+        .map((line) => {
+          const separator = line.indexOf('=');
+          return [line.slice(0, separator), normalizeEnvValue(line.slice(separator + 1))];
+        }),
+    )
+  : {});
+
+export const loadSmokeEnv = () => ({
+  ...loadEnvFile('.env'),
+  ...loadEnvFile('.env.local'),
+});

--- a/src/lib/smokeEnv.test.ts
+++ b/src/lib/smokeEnv.test.ts
@@ -1,0 +1,50 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+// @ts-expect-error Test imports a Node script module with named exports.
+import { loadSmokeEnv, normalizeEnvValue } from '../../scripts/smokeEnv.mjs';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('smoke env loader', () => {
+  it('normalizes quoted env values', () => {
+    expect(normalizeEnvValue(' "https://example.supabase.co" \n')).toBe('https://example.supabase.co');
+    expect(normalizeEnvValue("' anon-key \\n'")).toBe('anon-key');
+  });
+
+  it('merges .env and .env.local with local overrides', () => {
+    const cwd = process.cwd();
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), 'dayof-smoke-env-'));
+    tempDirs.push(tempDir);
+
+    writeFileSync(path.join(tempDir, '.env'), [
+      'VITE_SUPABASE_URL="https://base.supabase.co"',
+      'VITE_SUPABASE_ANON_KEY=base-key',
+      'SHARED_VALUE=from-base',
+    ].join('\n'));
+    writeFileSync(path.join(tempDir, '.env.local'), [
+      'VITE_SUPABASE_ANON_KEY="local-key"',
+      'LOCAL_ONLY=present',
+    ].join('\n'));
+
+    process.chdir(tempDir);
+    try {
+      expect(loadSmokeEnv()).toEqual({
+        VITE_SUPABASE_URL: 'https://base.supabase.co',
+        VITE_SUPABASE_ANON_KEY: 'local-key',
+        SHARED_VALUE: 'from-base',
+        LOCAL_ONLY: 'present',
+      });
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- load smoke env values from both `.env` and `.env.local` for RSVP and site lookup smoke scripts
- share the env parsing logic in a tiny helper instead of duplicating it in both scripts
- add a focused regression test for merged env loading and local override behavior

## Verification
- npm test -- --run src/lib/smokeEnv.test.ts
- npx eslint scripts/smokeEnv.mjs scripts/rsvp_smoke.js scripts/site_lookup_smoke.js src/lib/smokeEnv.test.ts
- git diff --check -- scripts/smokeEnv.mjs scripts/rsvp_smoke.js scripts/site_lookup_smoke.js src/lib/smokeEnv.test.ts