### PR TITLE
Keep RSVP token errors guest-safe

### DIFF
--- a/src/lib/validateRsvpTokenSafety.test.ts
+++ b/src/lib/validateRsvpTokenSafety.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('validate-rsvp-token safety guard', () => {
+  it('returns a guest-safe fallback instead of leaking raw unexpected errors', () => {
+    const functionSource = readFileSync(join(process.cwd(), 'supabase/functions/validate-rsvp-token/index.ts'), 'utf8');
+
+    expect(functionSource).toContain('VALIDATE_RSVP_TOKEN_UNEXPECTED_FAILED');
+    expect(functionSource).toContain('UNEXPECTED_RSVP_TOKEN_VALIDATION_FAILURE');
+    expect(functionSource).toContain('return json({ error: "Could not update this RSVP. Please try again." }, 500);');
+    expect(functionSource).not.toContain('const message = err instanceof Error ? err.message : "Internal server error";');
+    expect(functionSource).not.toContain('return json({ error: message }, 500);');
+  });
+});

--- a/supabase/functions/validate-rsvp-token/index.ts
+++ b/supabase/functions/validate-rsvp-token/index.ts
@@ -489,8 +489,10 @@ Deno.serve(async (req: Request) => {
     }
 
     return json({ error: "Unknown action" }, 400);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Internal server error";
-    return json({ error: message }, 500);
+  } catch {
+    console.error("VALIDATE_RSVP_TOKEN_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_RSVP_TOKEN_VALIDATION_FAILURE",
+    });
+    return json({ error: "Could not update this RSVP. Please try again." }, 500);
   }
 });


### PR DESCRIPTION
## Summary
- stop `validate-rsvp-token` from returning raw unexpected error messages to guests
- log a stable internal failure marker instead
- add a focused source guard so the guest-safe fallback stays in place

## Verification
- npm test -- --run src/lib/validateRsvpTokenSafety.test.ts
- npx eslint supabase/functions/validate-rsvp-token/index.ts src/lib/validateRsvpTokenSafety.test.ts
- git diff --check -- supabase/functions/validate-rsvp-token/index.ts src/lib/validateRsvpTokenSafety.test.ts