### PR TITLE
Keep wedding email errors guest-safe

### DIFF
--- a/src/lib/sendWeddingEmailSafety.test.ts
+++ b/src/lib/sendWeddingEmailSafety.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('send-wedding-email safety guard', () => {
+  it('keeps provider and unexpected email failures guest-safe', () => {
+    const functionSource = readFileSync(join(process.cwd(), 'supabase/functions/send-wedding-email/index.ts'), 'utf8');
+
+    expect(functionSource).toContain('SEND_WEDDING_EMAIL_PROVIDER_FAILED');
+    expect(functionSource).toContain('SEND_WEDDING_EMAIL_UNEXPECTED_FAILED');
+    expect(functionSource).toContain('UNEXPECTED_SEND_EMAIL_FAILURE');
+    expect(functionSource).toContain('return new Response(JSON.stringify({ error: "Could not send this email. Please try again." }), {');
+    expect(functionSource).not.toContain('return new Response(JSON.stringify({ error: "Failed to send email", details: errorBody }), {');
+    expect(functionSource).not.toContain('return new Response(JSON.stringify({ error: message }), {');
+    expect(functionSource).not.toContain('const message = err instanceof Error ? err.message : "Internal server error";');
+  });
+});

--- a/supabase/functions/send-wedding-email/index.ts
+++ b/supabase/functions/send-wedding-email/index.ts
@@ -308,7 +308,7 @@ Deno.serve(async (req: Request) => {
 
     const resendApiKey = Deno.env.get("RESEND_API_KEY");
     if (!resendApiKey) {
-      return new Response(JSON.stringify({ error: "Email service not configured" }), {
+      return new Response(JSON.stringify({ error: "Could not send this email. Please try again." }), {
         status: 500,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -368,9 +368,8 @@ Deno.serve(async (req: Request) => {
     });
 
     if (!resendResponse.ok) {
-      const errorBody = await resendResponse.text();
-      console.error("Resend error:", errorBody);
-      return new Response(JSON.stringify({ error: "Failed to send email", details: errorBody }), {
+      console.error("SEND_WEDDING_EMAIL_PROVIDER_FAILED", { status: resendResponse.status });
+      return new Response(JSON.stringify({ error: "Could not send this email. Please try again." }), {
         status: 500,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -382,9 +381,11 @@ Deno.serve(async (req: Request) => {
       status: 200,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Internal server error";
-    return new Response(JSON.stringify({ error: message }), {
+  } catch {
+    console.error("SEND_WEDDING_EMAIL_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_SEND_EMAIL_FAILURE",
+    });
+    return new Response(JSON.stringify({ error: "Could not send this email. Please try again." }), {
       status: 500,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- stop `send-wedding-email` from returning provider details or raw exception messages to guests
- log stable internal failure markers for provider and unexpected failures
- add a focused source guard so the guest-safe fallback stays in place

## Verification
- npm test -- --run src/lib/sendWeddingEmailSafety.test.ts
- npx eslint supabase/functions/send-wedding-email/index.ts src/lib/sendWeddingEmailSafety.test.ts
- git diff --check -- supabase/functions/send-wedding-email/index.ts src/lib/sendWeddingEmailSafety.test.ts