### PR TITLE
Keep email queue errors guest-safe

### DIFF
--- a/src/lib/processEmailQueueSafety.test.ts
+++ b/src/lib/processEmailQueueSafety.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('process-email-queue safety guard', () => {
+  it('keeps unexpected queue failures guest-safe', () => {
+    const functionSource = readFileSync(join(process.cwd(), 'supabase/functions/process-email-queue/index.ts'), 'utf8');
+
+    expect(functionSource).toContain('PROCESS_EMAIL_QUEUE_UNEXPECTED_FAILED');
+    expect(functionSource).toContain('UNEXPECTED_EMAIL_QUEUE_FAILURE');
+    expect(functionSource).toContain('return json({ error: "Could not process email queue. Please try again." }, 500);');
+    expect(functionSource).not.toContain('const message = err instanceof Error ? err.message : "Internal server error";');
+    expect(functionSource).not.toContain('return json({ error: message }, 500);');
+  });
+});

--- a/supabase/functions/process-email-queue/index.ts
+++ b/supabase/functions/process-email-queue/index.ts
@@ -175,8 +175,10 @@ Deno.serve(async (req: Request) => {
     }
 
     return json({ processed: items.length, delivered, failed });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Internal server error";
-    return json({ error: message }, 500);
+  } catch {
+    console.error("PROCESS_EMAIL_QUEUE_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_EMAIL_QUEUE_FAILURE",
+    });
+    return json({ error: "Could not process email queue. Please try again." }, 500);
   }
 });


### PR DESCRIPTION
## Summary
- stop `process-email-queue` from returning raw unexpected error messages to callers
- log a stable internal failure marker instead
- add a focused source guard so the guest-safe fallback stays in place

## Verification
- npm test -- --run src/lib/processEmailQueueSafety.test.ts
- npx eslint supabase/functions/process-email-queue/index.ts src/lib/processEmailQueueSafety.test.ts
- git diff --check -- supabase/functions/process-email-queue/index.ts src/lib/processEmailQueueSafety.test.ts