### PR TITLE
Keep contact request errors guest-safe

### DIFF
--- a/src/lib/submitContactRequestSafety.test.ts
+++ b/src/lib/submitContactRequestSafety.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("submit-contact-request safety", () => {
+  it("keeps update and unexpected failures guest-safe", () => {
+    const source = readFileSync(join(process.cwd(), "supabase/functions/submit-contact-request/index.ts"), "utf8");
+
+    expect(source).toContain("SUBMIT_CONTACT_REQUEST_UPDATE_FAILED");
+    expect(source).toContain("GUEST_CONTACT_REQUEST_UPDATE_FAILED");
+    expect(source).toContain("SUBMIT_CONTACT_REQUEST_UNEXPECTED_FAILED");
+    expect(source).toContain("UNEXPECTED_CONTACT_REQUEST_FAILURE");
+    expect(source).toContain('JSON.stringify({ error: "Could not update this guest. Please try again." })');
+    expect(source).not.toContain("JSON.stringify({ error: guestErr.message })");
+    expect(source).not.toContain('JSON.stringify({ error: err instanceof Error ? err.message : "Internal error" })');
+  });
+});

--- a/supabase/functions/submit-contact-request/index.ts
+++ b/supabase/functions/submit-contact-request/index.ts
@@ -59,7 +59,13 @@ Deno.serve(async (req: Request) => {
       .eq("wedding_site_id", requestRow.wedding_site_id);
 
     if (guestErr) {
-      return new Response(JSON.stringify({ error: guestErr.message }), { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+      console.error("SUBMIT_CONTACT_REQUEST_UPDATE_FAILED", {
+        reason: "GUEST_CONTACT_REQUEST_UPDATE_FAILED",
+      });
+      return new Response(JSON.stringify({ error: "Could not update this guest. Please try again." }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
     await admin
@@ -68,8 +74,11 @@ Deno.serve(async (req: Request) => {
       .eq("id", requestRow.id);
 
     return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } });
-  } catch (err) {
-    return new Response(JSON.stringify({ error: err instanceof Error ? err.message : "Internal error" }), {
+  } catch {
+    console.error("SUBMIT_CONTACT_REQUEST_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_CONTACT_REQUEST_FAILURE",
+    });
+    return new Response(JSON.stringify({ error: "Could not update this guest. Please try again." }), {
       status: 500,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- keep submit-contact-request update and unexpected failures guest-safe
- log stable internal markers instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/submitContactRequestSafety.test.ts
- npx eslint supabase/functions/submit-contact-request/index.ts src/lib/submitContactRequestSafety.test.ts
- git diff --check -- supabase/functions/submit-contact-request/index.ts src/lib/submitContactRequestSafety.test.ts