### PR TITLE
Keep guest contact submit errors guest-safe

### DIFF
--- a/src/lib/guestContactSubmitSafety.test.ts
+++ b/src/lib/guestContactSubmitSafety.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("guest-contact-submit safety", () => {
+  it("keeps update and unexpected failures guest-safe", () => {
+    const source = readFileSync(join(process.cwd(), "supabase/functions/guest-contact-submit/index.ts"), "utf8");
+
+    expect(source).toContain("GUEST_CONTACT_SUBMIT_UPDATE_FAILED");
+    expect(source).toContain("GUEST_CONTACT_SUBMIT_UPDATE_ERROR");
+    expect(source).toContain("GUEST_CONTACT_SUBMIT_UNEXPECTED_FAILED");
+    expect(source).toContain("UNEXPECTED_GUEST_CONTACT_SUBMIT_FAILURE");
+    expect(source).toContain('JSON.stringify({ error: "Could not update this guest. Please try again." })');
+    expect(source).not.toContain("JSON.stringify({ error: updateError.message })");
+    expect(source).not.toContain('JSON.stringify({ error: err instanceof Error ? err.message : "Internal error" })');
+  });
+});

--- a/supabase/functions/guest-contact-submit/index.ts
+++ b/supabase/functions/guest-contact-submit/index.ts
@@ -18,7 +18,6 @@ Deno.serve(async (req: Request) => {
     const email = String(body.email ?? "").trim() || null;
     const phone = String(body.phone ?? "").trim() || null;
     const rsvpStatus = String(body.rsvp_status ?? "").trim() || null;
-    const smsConsent = Boolean(body.sms_consent ?? false);
     const mailingAddressLine1 = String(body.mailing_address_line1 ?? '').trim() || null;
     const mailingAddressLine2 = String(body.mailing_address_line2 ?? '').trim() || null;
     const mailingCity = String(body.mailing_city ?? '').trim() || null;
@@ -78,15 +77,24 @@ Deno.serve(async (req: Request) => {
 
     const { error: updateError } = await query;
     if (updateError) {
-      return new Response(JSON.stringify({ error: updateError.message }), { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+      console.error("GUEST_CONTACT_SUBMIT_UPDATE_FAILED", {
+        reason: "GUEST_CONTACT_SUBMIT_UPDATE_ERROR",
+      });
+      return new Response(JSON.stringify({ error: "Could not update this guest. Please try again." }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
     return new Response(JSON.stringify({ ok: true }), {
       status: 200,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
-  } catch (err) {
-    return new Response(JSON.stringify({ error: err instanceof Error ? err.message : "Internal error" }), {
+  } catch {
+    console.error("GUEST_CONTACT_SUBMIT_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_GUEST_CONTACT_SUBMIT_FAILURE",
+    });
+    return new Response(JSON.stringify({ error: "Could not update this guest. Please try again." }), {
       status: 500,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- keep guest-contact-submit update and unexpected failures guest-safe
- log stable internal markers instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/guestContactSubmitSafety.test.ts
- npx eslint supabase/functions/guest-contact-submit/index.ts src/lib/guestContactSubmitSafety.test.ts
- git diff --check -- supabase/functions/guest-contact-submit/index.ts src/lib/guestContactSubmitSafety.test.ts