### PR TITLE
Keep submit RSVP errors guest-safe

### DIFF
--- a/src/lib/submitRsvpSafety.test.ts
+++ b/src/lib/submitRsvpSafety.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("submit-rsvp safety", () => {
+  it("keeps unexpected failures guest-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/submit-rsvp/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("SUBMIT_RSVP_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_SUBMIT_RSVP_FAILURE"');
+    expect(functionSource).toContain('return json({ error: "Could not submit this RSVP. Please try again." }, 500);');
+    expect(functionSource).not.toContain('const message = err instanceof Error ? err.message : "Internal server error";');
+    expect(functionSource).not.toContain("return json({ error: message }, 500);");
+  });
+});

--- a/supabase/functions/submit-rsvp/index.ts
+++ b/supabase/functions/submit-rsvp/index.ts
@@ -273,8 +273,10 @@ Deno.serve(async (req: Request) => {
           }
         : null,
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Internal server error";
-    return json({ error: message }, 500);
+  } catch {
+    console.error("SUBMIT_RSVP_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_SUBMIT_RSVP_FAILURE",
+    });
+    return json({ error: "Could not submit this RSVP. Please try again." }, 500);
   }
 });


### PR DESCRIPTION
## Summary
- keep submit-rsvp unexpected failures guest-safe
- log a stable internal marker instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/submitRsvpSafety.test.ts
- npx eslint supabase/functions/submit-rsvp/index.ts src/lib/submitRsvpSafety.test.ts
- git diff --check -- supabase/functions/submit-rsvp/index.ts src/lib/submitRsvpSafety.test.ts