### PR TITLE
Keep generate token errors guest-safe

### DIFF
--- a/src/lib/generateTokenSafety.test.ts
+++ b/src/lib/generateTokenSafety.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("generate-token safety", () => {
+  it("keeps unexpected failures guest-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/generate-token/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("GENERATE_TOKEN_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_GENERATE_TOKEN_FAILURE"');
+    expect(functionSource).toContain('return json({ error: "Could not generate a token. Please try again." }, 500);');
+    expect(functionSource).not.toContain('const message = err instanceof Error ? err.message : "Internal server error";');
+    expect(functionSource).not.toContain("return json({ error: message }, 500);");
+  });
+});

--- a/supabase/functions/generate-token/index.ts
+++ b/supabase/functions/generate-token/index.ts
@@ -69,8 +69,10 @@ Deno.serve(async (req: Request) => {
     }
 
     return json({ tokens });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Internal server error";
-    return json({ error: message }, 500);
+  } catch {
+    console.error("GENERATE_TOKEN_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_GENERATE_TOKEN_FAILURE",
+    });
+    return json({ error: "Could not generate a token. Please try again." }, 500);
   }
 });


### PR DESCRIPTION
## Summary
- keep generate-token unexpected failures guest-safe
- log a stable internal marker instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/generateTokenSafety.test.ts
- npx eslint supabase/functions/generate-token/index.ts src/lib/generateTokenSafety.test.ts
- git diff --check -- supabase/functions/generate-token/index.ts src/lib/generateTokenSafety.test.ts