### PR TITLE
Keep Stripe checkout errors guest-safe

### DIFF
--- a/src/lib/stripeCreateCheckoutSafety.test.ts
+++ b/src/lib/stripeCreateCheckoutSafety.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("stripe-create-checkout safety", () => {
+  it("keeps unexpected failures guest-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/stripe-create-checkout/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("STRIPE_CREATE_CHECKOUT_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_STRIPE_CREATE_CHECKOUT_FAILURE"');
+    expect(functionSource).toContain('JSON.stringify({ error: "Could not start checkout. Please try again." })');
+    expect(functionSource).not.toContain('const message = err instanceof Error ? err.message : "Internal server error";');
+    expect(functionSource).not.toContain('JSON.stringify({ error: message })');
+  });
+});

--- a/supabase/functions/stripe-create-checkout/index.ts
+++ b/supabase/functions/stripe-create-checkout/index.ts
@@ -111,9 +111,11 @@ Deno.serve(async (req: Request) => {
       status: 200,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Internal server error";
-    return new Response(JSON.stringify({ error: message }), {
+  } catch {
+    console.error("STRIPE_CREATE_CHECKOUT_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_STRIPE_CREATE_CHECKOUT_FAILURE",
+    });
+    return new Response(JSON.stringify({ error: "Could not start checkout. Please try again." }), {
       status: 500,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- keep stripe-create-checkout unexpected failures guest-safe
- log a stable internal marker instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/stripeCreateCheckoutSafety.test.ts
- npx eslint supabase/functions/stripe-create-checkout/index.ts src/lib/stripeCreateCheckoutSafety.test.ts
- git diff --check -- supabase/functions/stripe-create-checkout/index.ts src/lib/stripeCreateCheckoutSafety.test.ts