### PR TITLE
Keep Stripe verify checkout errors guest-safe

### DIFF
--- a/src/lib/stripeVerifyCheckoutSessionSafety.test.ts
+++ b/src/lib/stripeVerifyCheckoutSessionSafety.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("stripe-verify-checkout-session safety", () => {
+  it("keeps update and unexpected failures guest-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/stripe-verify-checkout-session/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("STRIPE_VERIFY_CHECKOUT_SESSION_UPDATE_FAILED"');
+    expect(functionSource).toContain('reason: "STRIPE_VERIFY_CHECKOUT_SESSION_UPDATE_ERROR"');
+    expect(functionSource).toContain('console.error("STRIPE_VERIFY_CHECKOUT_SESSION_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_STRIPE_VERIFY_CHECKOUT_SESSION_FAILURE"');
+    expect(functionSource).toContain('JSON.stringify({ error: "Could not verify this checkout session. Please try again." })');
+    expect(functionSource).not.toContain("JSON.stringify({ error: updateError.message })");
+    expect(functionSource).not.toContain('const message = err instanceof Error ? err.message : "Internal server error";');
+    expect(functionSource).not.toContain('JSON.stringify({ error: message })');
+  });
+});

--- a/supabase/functions/stripe-verify-checkout-session/index.ts
+++ b/supabase/functions/stripe-verify-checkout-session/index.ts
@@ -96,7 +96,10 @@ Deno.serve(async (req: Request) => {
       .eq("user_id", user.id);
 
     if (updateError) {
-      return new Response(JSON.stringify({ error: updateError.message }), {
+      console.error("STRIPE_VERIFY_CHECKOUT_SESSION_UPDATE_FAILED", {
+        reason: "STRIPE_VERIFY_CHECKOUT_SESSION_UPDATE_ERROR",
+      });
+      return new Response(JSON.stringify({ error: "Could not verify this checkout session. Please try again." }), {
         status: 500,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -106,9 +109,11 @@ Deno.serve(async (req: Request) => {
       status: 200,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Internal server error";
-    return new Response(JSON.stringify({ error: message }), {
+  } catch {
+    console.error("STRIPE_VERIFY_CHECKOUT_SESSION_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_STRIPE_VERIFY_CHECKOUT_SESSION_FAILURE",
+    });
+    return new Response(JSON.stringify({ error: "Could not verify this checkout session. Please try again." }), {
       status: 500,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- keep stripe-verify-checkout-session update and unexpected failures guest-safe
- log stable internal markers instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/stripeVerifyCheckoutSessionSafety.test.ts
- npx eslint supabase/functions/stripe-verify-checkout-session/index.ts src/lib/stripeVerifyCheckoutSessionSafety.test.ts
- git diff --check -- supabase/functions/stripe-verify-checkout-session/index.ts src/lib/stripeVerifyCheckoutSessionSafety.test.ts