### PR TITLE
Keep client error logging guest-safe

### DIFF
--- a/src/lib/logClientErrorSafety.test.ts
+++ b/src/lib/logClientErrorSafety.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("log-client-error safety", () => {
+  it("keeps insert and unexpected failures guest-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/log-client-error/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("LOG_CLIENT_ERROR_INSERT_FAILED"');
+    expect(functionSource).toContain('reason: "APP_ERROR_LOG_INSERT_FAILED"');
+    expect(functionSource).toContain('console.error("LOG_CLIENT_ERROR_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_CLIENT_ERROR_LOG_FAILURE"');
+    expect(functionSource).toContain('return json({ error: "Could not record this error report. Please try again." }, 500);');
+    expect(functionSource).not.toContain("return json({ error: error.message }, 500);");
+    expect(functionSource).not.toContain('const msg = err instanceof Error ? err.message : "Internal error";');
+    expect(functionSource).not.toContain("return json({ error: msg }, 500);");
+  });
+});

--- a/supabase/functions/log-client-error/index.ts
+++ b/supabase/functions/log-client-error/index.ts
@@ -104,10 +104,17 @@ Deno.serve(async (req: Request) => {
       metadata,
     });
 
-    if (error) return json({ error: error.message }, 500);
+    if (error) {
+      console.error("LOG_CLIENT_ERROR_INSERT_FAILED", {
+        reason: "APP_ERROR_LOG_INSERT_FAILED",
+      });
+      return json({ error: "Could not record this error report. Please try again." }, 500);
+    }
     return json({ ok: true });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : "Internal error";
-    return json({ error: msg }, 500);
+  } catch {
+    console.error("LOG_CLIENT_ERROR_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_CLIENT_ERROR_LOG_FAILURE",
+    });
+    return json({ error: "Could not record this error report. Please try again." }, 500);
   }
 });


### PR DESCRIPTION
## Summary
- keep log-client-error insert and unexpected failures guest-safe
- log stable internal markers instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/logClientErrorSafety.test.ts
- npx eslint supabase/functions/log-client-error/index.ts src/lib/logClientErrorSafety.test.ts
- git diff --check -- supabase/functions/log-client-error/index.ts src/lib/logClientErrorSafety.test.ts