### PR TITLE
Keep Google Drive health errors admin-safe

### DIFF
--- a/src/lib/googleDriveHealthSafety.test.ts
+++ b/src/lib/googleDriveHealthSafety.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("google-drive-health safety", () => {
+  it("keeps unexpected failures admin-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/google-drive-health/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("GOOGLE_DRIVE_HEALTH_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_GOOGLE_DRIVE_HEALTH_FAILURE"');
+    expect(functionSource).toContain('message: "Could not verify Google Drive health. Please reconnect and try again."');
+    expect(functionSource).not.toContain('message: err instanceof Error ? err.message : "Health check failed."');
+  });
+});

--- a/supabase/functions/google-drive-health/index.ts
+++ b/supabase/functions/google-drive-health/index.ts
@@ -114,7 +114,15 @@ Deno.serve(async (req: Request) => {
       refreshed,
       message: refreshed ? "Drive token refreshed and healthy." : "Drive connection healthy.",
     });
-  } catch (err) {
-    return json({ connected: true, healthy: false, needsReconnect: true, message: err instanceof Error ? err.message : "Health check failed." }, 500);
+  } catch {
+    console.error("GOOGLE_DRIVE_HEALTH_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_GOOGLE_DRIVE_HEALTH_FAILURE",
+    });
+    return json({
+      connected: true,
+      healthy: false,
+      needsReconnect: true,
+      message: "Could not verify Google Drive health. Please reconnect and try again.",
+    }, 500);
   }
 });


### PR DESCRIPTION
## Summary
- keep google-drive-health unexpected failures admin-safe
- log a stable internal marker instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/googleDriveHealthSafety.test.ts
- npx eslint supabase/functions/google-drive-health/index.ts src/lib/googleDriveHealthSafety.test.ts
- git diff --check -- supabase/functions/google-drive-health/index.ts src/lib/googleDriveHealthSafety.test.ts