### PR TITLE
Keep photo moderation errors admin-safe

### DIFF
--- a/src/lib/photoUploadModerateSafety.test.ts
+++ b/src/lib/photoUploadModerateSafety.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("photo-upload-moderate safety", () => {
+  it("keeps update and unexpected failures admin-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/photo-upload-moderate/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("PHOTO_UPLOAD_MODERATE_UPDATE_FAILED"');
+    expect(functionSource).toContain('reason: "PHOTO_UPLOAD_MODERATION_UPDATE_ERROR"');
+    expect(functionSource).toContain('console.error("PHOTO_UPLOAD_MODERATE_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_PHOTO_UPLOAD_MODERATION_FAILURE"');
+    expect(functionSource).toContain('fail("DB_ERROR", "Could not update photo moderation. Please try again.", 400)');
+    expect(functionSource).toContain('fail("INTERNAL_ERROR", "Could not update photo moderation. Please try again.", 500)');
+    expect(functionSource).not.toContain('fail("DB_ERROR", updateErr.message, 400)');
+    expect(functionSource).not.toContain('fail("INTERNAL_ERROR", err instanceof Error ? err.message : "Internal server error", 500)');
+  });
+});

--- a/supabase/functions/photo-upload-moderate/index.ts
+++ b/supabase/functions/photo-upload-moderate/index.ts
@@ -63,10 +63,18 @@ Deno.serve(async (req: Request) => {
       })
       .in("id", uploadIds);
 
-    if (updateErr) return fail("DB_ERROR", updateErr.message, 400);
+    if (updateErr) {
+      console.error("PHOTO_UPLOAD_MODERATE_UPDATE_FAILED", {
+        reason: "PHOTO_UPLOAD_MODERATION_UPDATE_ERROR",
+      });
+      return fail("DB_ERROR", "Could not update photo moderation. Please try again.", 400);
+    }
 
     return json({ success: true, updated: uploadIds.length });
-  } catch (err) {
-    return fail("INTERNAL_ERROR", err instanceof Error ? err.message : "Internal server error", 500);
+  } catch {
+    console.error("PHOTO_UPLOAD_MODERATE_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_PHOTO_UPLOAD_MODERATION_FAILURE",
+    });
+    return fail("INTERNAL_ERROR", "Could not update photo moderation. Please try again.", 500);
   }
 });


### PR DESCRIPTION
## Summary
- keep photo-upload-moderate update and unexpected failures admin-safe
- log stable internal markers instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/photoUploadModerateSafety.test.ts
- npx eslint supabase/functions/photo-upload-moderate/index.ts src/lib/photoUploadModerateSafety.test.ts
- git diff --check -- supabase/functions/photo-upload-moderate/index.ts src/lib/photoUploadModerateSafety.test.ts