### PR TITLE
Keep photo upload errors guest-safe

### DIFF
--- a/src/lib/photoUploadSafety.test.ts
+++ b/src/lib/photoUploadSafety.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("photo-upload safety", () => {
+  it("keeps unexpected failures guest-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/photo-upload/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("PHOTO_UPLOAD_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_PHOTO_UPLOAD_FAILURE"');
+    expect(functionSource).toContain('return fail("INTERNAL_ERROR", "Could not upload files. Please try again.", 500);');
+    expect(functionSource).not.toContain('return fail("INTERNAL_ERROR", err instanceof Error ? err.message : "Internal server error", 500);');
+  });
+});

--- a/supabase/functions/photo-upload/index.ts
+++ b/supabase/functions/photo-upload/index.ts
@@ -284,7 +284,10 @@ Deno.serve(async (req: Request) => {
       failed,
       partial: failed.length > 0,
     });
-  } catch (err) {
-    return fail("INTERNAL_ERROR", err instanceof Error ? err.message : "Internal server error", 500);
+  } catch {
+    console.error("PHOTO_UPLOAD_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_PHOTO_UPLOAD_FAILURE",
+    });
+    return fail("INTERNAL_ERROR", "Could not upload files. Please try again.", 500);
   }
 });


### PR DESCRIPTION
## Summary
- keep photo-upload unexpected failures guest-safe
- log a stable internal marker instead of returning raw backend messages
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/photoUploadSafety.test.ts
- npx eslint supabase/functions/photo-upload/index.ts src/lib/photoUploadSafety.test.ts
- git diff --check -- supabase/functions/photo-upload/index.ts src/lib/photoUploadSafety.test.ts