### PR TITLE
Keep photo album creation errors admin-safe

### DIFF
--- a/src/lib/photoAlbumCreateSafety.test.ts
+++ b/src/lib/photoAlbumCreateSafety.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("photo-album-create safety", () => {
+  it("keeps insert and unexpected failures admin-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/photo-album-create/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("PHOTO_ALBUM_CREATE_INSERT_FAILED"');
+    expect(functionSource).toContain('reason: "PHOTO_ALBUM_CREATE_INSERT_ERROR"');
+    expect(functionSource).toContain('console.error("PHOTO_ALBUM_CREATE_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_PHOTO_ALBUM_CREATE_FAILURE"');
+    expect(functionSource).toContain('fail("DB_ERROR", "Could not create this album. Please try again.", 400)');
+    expect(functionSource).toContain('fail("INTERNAL_ERROR", "Could not create this album. Please try again.", 500)');
+    expect(functionSource).not.toContain('fail("DB_ERROR", error.message, 400)');
+    expect(functionSource).not.toContain('fail("INTERNAL_ERROR", err instanceof Error ? err.message : "Internal server error", 500)');
+  });
+});

--- a/supabase/functions/photo-album-create/index.ts
+++ b/supabase/functions/photo-album-create/index.ts
@@ -176,7 +176,12 @@ Deno.serve(async (req: Request) => {
       .select("id,name,slug,drive_folder_id,drive_folder_url")
       .single();
 
-    if (error) return fail("DB_ERROR", error.message, 400);
+    if (error) {
+      console.error("PHOTO_ALBUM_CREATE_INSERT_FAILED", {
+        reason: "PHOTO_ALBUM_CREATE_INSERT_ERROR",
+      });
+      return fail("DB_ERROR", "Could not create this album. Please try again.", 400);
+    }
 
     const uploadUrl = `${appUrl.replace(/\/$/, "")}/photos/upload?t=${encodeURIComponent(token)}`;
 
@@ -185,7 +190,10 @@ Deno.serve(async (req: Request) => {
       uploadUrl,
       uploadToken: token,
     });
-  } catch (err) {
-    return fail("INTERNAL_ERROR", err instanceof Error ? err.message : "Internal server error", 500);
+  } catch {
+    console.error("PHOTO_ALBUM_CREATE_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_PHOTO_ALBUM_CREATE_FAILURE",
+    });
+    return fail("INTERNAL_ERROR", "Could not create this album. Please try again.", 500);
   }
 });


### PR DESCRIPTION
## Summary
- keep photo album creation database failures admin-safe
- keep unexpected photo album creation failures admin-safe
- add a focused source guard for the new fallback contract

## Verification
- npm test -- --run src/lib/photoAlbumCreateSafety.test.ts
- npx eslint supabase/functions/photo-album-create/index.ts src/lib/photoAlbumCreateSafety.test.ts
- git diff --check -- supabase/functions/photo-album-create/index.ts src/lib/photoAlbumCreateSafety.test.ts