### PR TITLE
Keep setup bootstrap errors admin-safe

### DIFF
--- a/src/lib/setupBootstrapSafety.test.ts
+++ b/src/lib/setupBootstrapSafety.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("setup-bootstrap safety", () => {
+  it("keeps unexpected failures admin-safe", () => {
+    const functionSource = readFileSync(join(process.cwd(), "supabase/functions/setup-bootstrap/index.ts"), "utf8");
+
+    expect(functionSource).toContain('console.error("SETUP_BOOTSTRAP_UNEXPECTED_FAILED"');
+    expect(functionSource).toContain('reason: "UNEXPECTED_SETUP_BOOTSTRAP_FAILURE"');
+    expect(functionSource).toContain('fail("INTERNAL_ERROR", "Could not finish setup bootstrap. Please try again.", 500)');
+    expect(functionSource).not.toContain('fail("INTERNAL_ERROR", err instanceof Error ? err.message : "Internal server error", 500)');
+  });
+});

--- a/supabase/functions/setup-bootstrap/index.ts
+++ b/supabase/functions/setup-bootstrap/index.ts
@@ -135,7 +135,10 @@ Deno.serve(async (req: Request) => {
     if (updateErr) return fail("DB_ERROR", updateErr.message, 400);
 
     return json({ success: true, weddingSiteId: site.id });
-  } catch (err) {
-    return fail("INTERNAL_ERROR", err instanceof Error ? err.message : "Internal server error", 500);
+  } catch {
+    console.error("SETUP_BOOTSTRAP_UNEXPECTED_FAILED", {
+      reason: "UNEXPECTED_SETUP_BOOTSTRAP_FAILURE",
+    });
+    return fail("INTERNAL_ERROR", "Could not finish setup bootstrap. Please try again.", 500);
   }
 });


### PR DESCRIPTION
## Summary
- keep unexpected setup bootstrap failures admin-safe
- log a stable internal marker instead of leaking raw exception text
- add a focused source guard for the fallback contract

## Verification
- npm test -- --run src/lib/setupBootstrapSafety.test.ts
- npx eslint supabase/functions/setup-bootstrap/index.ts src/lib/setupBootstrapSafety.test.ts
- git diff --check -- supabase/functions/setup-bootstrap/index.ts src/lib/setupBootstrapSafety.test.ts