### PR TITLE
Refresh release readiness docs

### DIFF
--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -2,6 +2,35 @@
 
 Run this before every production deployment.
 
+## Release Readiness Refresh — 2026-05-26
+
+### Current Branch Truth
+
+- `main` is clean and synced with `origin/main`
+- latest merge on `main`: `151354afb` (`Merge pull request #94 from jeanericgagnon/codex-deploy-readiness-main-audit`)
+- latest `main` hardpass GitHub run: `success`
+
+### Current Audit Results
+
+| Check | Result |
+|---|---|
+| `npm run build` | PASS |
+| `npm run test:security` | PASS |
+| `npm run proof:v1:strict-pocket` | PASS |
+| `npm run smoke:registry` | PASS |
+| `npm run test:smoke` | PASS |
+| Fresh worktree `npm ci` | PASS |
+| Fresh worktree `npm run typecheck -- --pretty false` | PASS |
+
+### Deploy Readiness Call
+
+**GO, with one environment note**
+
+- The launch-blocking registry smoke drift and missing barcode lookup lane were repaired in PR #94.
+- Current `main` passed the launch-critical local and live-smoke audit after those repairs.
+- A fresh-install typecheck pass confirmed the earlier local checkout typecheck failure was environment contamination, not repo source truth.
+- Local `npm ci` on Node 22 surfaced an engine warning from `@zxing/library`, while GitHub hardpass already uses Node 24. Prefer deploying and CI-verifying on the Node 24 lane.
+
 ## Pre-Deploy Quality Gate
 
 - [ ] `npm run typecheck` — 0 errors

--- a/docs/v1-smoke-proof-log.md
+++ b/docs/v1-smoke-proof-log.md
@@ -8,6 +8,22 @@ _Launch call right now:_ `GO`
 
 ## Current Truth
 
+- 2026-05-26 10:25 AM PDT:
+  - merged deploy-readiness audit PR #94 onto `main` (`151354afb`)
+  - repaired current launch blockers in the audit lane:
+    - stale `proof:v1:strict-pocket` launch-critical file list
+    - stale `smoke:registry` assertions
+    - missing `registry-barcode-lookup` source/test lane used by current registry flows
+  - `npm run build` -> `PASS`
+  - `npm run test:security` -> `PASS`
+  - `npm run proof:v1:strict-pocket` -> `PASS`
+  - `npm run test:smoke` -> `PASS`
+  - fresh temporary worktree:
+    - `npm ci` -> `PASS`
+    - `npm run typecheck -- --pretty false` -> `PASS`
+  - `hardpass-rsvp` on `main` for SHA `151354afb` -> `SUCCESS`
+  - no deploy was run; latest verified live deploy remains `dpl_DQG5bU5yVbqT79Y6r4ZCx13nPtSU`
+  - current launch call from repo + CI truth: `GO`, with the operational note that GitHub hardpass uses Node 24 and local Node 22 still surfaces an `@zxing/library` engine warning during clean install
 - 2026-05-21 08:46 PM PDT:
   - added a headless registry maintenance proof lane in `scripts/v1-proof-registry-maintenance-report.mjs`
   - the proof now reads the same shared registry maintenance snapshot as the dashboard cleanup surface


### PR DESCRIPTION
## Summary
- record the current deploy-readiness audit results in the deployment checklist
- add the latest main/CI truth to the v1 smoke proof log

## Notes
- no runtime behavior changes
- captures the current GO call from the merged deploy-readiness audit and fresh-install typecheck pass