### PR TITLE
Recover newer public marketing UI

### DIFF
--- a/src/lib/proofBoardFreshness.test.ts
+++ b/src/lib/proofBoardFreshness.test.ts
@@ -21,7 +21,7 @@ type ProofBoardOutput = {
 };
 
 const read = (path: string) => readFileSync(path, 'utf8');
-const FRESH_GENERATED_AT = '2026-05-24 04:16 PM PT';
+const FRESH_GENERATED_AT = '2026-05-26 11:22 PM PT';
 
 const parseCurrentStateTable = (text: string) => {
   const lines = text.split(/\r?\n/);
@@ -86,12 +86,12 @@ describe('proof board freshness', () => {
     expect(board.currentState).toMatchObject(expectedState);
     expect(board.activeUngatedLaunchBlockers ?? []).toEqual(expectedBlockers);
     expect(board.currentStateFreshness?.status).toBe('FRESH');
-    expect(board.summary?.currentProofState).toContain('proof:v1:full-suite-exit-gate');
-    expect(board.summary?.currentProofState).toContain('proof:v1:board:freshness');
+    expect(board.summary?.currentProofState).toContain('proof:v1:canonical-smoke');
+    expect(board.summary?.currentProofState).toContain('proof:v1:guests-rsvp-ops');
     expect(board.summary?.currentNextActions ?? '').toContain('proof:v1:board:freshness');
     expect(board.activeUngatedLaunchBlockers ?? []).toEqual([]);
-    expect(board.sections?.['Current Canonical Status']).toContain('| Current launch verdict | `FULL-SUITE READY FOR THE ACTIVE THREE-LANE SCOPE` |');
-    expect(board.sections?.['Current Canonical Status']).toContain('| Production-ready | `YES FOR DAY-OF / COORDINATOR, NAME CHANGE, AND REGISTRY BARCODE` |');
+    expect(board.sections?.['Current Canonical Status']).toContain('| Current launch verdict | `GO` |');
+    expect(board.sections?.['Current Canonical Status']).toContain('| Production-ready | `YES FOR THE CURRENT PUBLIC / GUEST / RSVP LAUNCH SCOPE` |');
     expect(board.sections?.['Deployment Matrix']).toContain('guest-contact-lookup');
   });
 
@@ -117,7 +117,7 @@ describe('proof board freshness', () => {
 
     const staleBacklogPath = join(tempDir, 'BACKLOG.md');
     const staleBacklog = read('BACKLOG.md').replace(
-      '| Current date/time | `2026-05-24 04:16 PM PDT` |',
+      '| Current date/time | `2026-05-26 11:22 PM PDT` |',
       '| Current date/time | `2026-05-15 02:26 PM PDT` |',
     );
     writeFileSync(staleBacklogPath, staleBacklog);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,671 +1,532 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Header, Footer } from '../components/layout';
-import { useAuth } from '../hooks/useAuth';
-import { useToast } from '../components/ui/Toast';
-import { SITE_TRUST_COPY } from '../lib/siteTrustCopy';
 import {
-  Heart,
-  Users,
-  Mail,
-  Calendar,
-  CheckCircle2,
-  Hotel,
-  ChevronDown,
   ArrowRight,
+  Calendar,
+  Camera,
+  CheckCircle2,
+  Heart,
+  Mail,
   Radio,
+  Shield,
+  Users,
 } from 'lucide-react';
-import { HeroReveal, Reveal, SlideReveal } from '../components/marketing/Reveal';
+import { Footer, Header } from '../components/layout';
+import { HeroReveal, Reveal } from '../components/marketing/Reveal';
+import { useToast } from '../components/ui/Toast';
+import { useAuth } from '../hooks/useAuth';
+import { SITE_TRUST_COPY } from '../lib/siteTrustCopy';
+import { DEMO_MODE } from '../config/env';
 
-const V1_HOME_GROUPS = [
+const asset = (name: string) => `${import.meta.env.BASE_URL}landing/${name}`;
+
+const heroStats = [
+  ['Site', 'Templates, travel, registry, and RSVP in one public home.'],
+  ['Guests', 'Households, messages, meals, seating, and check-in stay connected.'],
+  ['After', 'Photos, guestbook, vault, recap, and name-change follow-through.'],
+] as const;
+
+const operatingSystemRows = [
   {
-    title: 'Core v1 today',
-    badge: 'Must ship',
-    tone: 'must',
-    items: [
-      'Wedding site, RSVP, guests, messaging, seating, registry, itinerary, and day-of coordination in one coherent flow',
-      'Planner/coordinator access that stays couple-led and role-aware',
-      SITE_TRUST_COPY.guestAccessTruth,
-    ],
+    title: 'The wedding site is the front door',
+    body: 'Guests get a beautiful place for the details, not a dead page that stops helping after publish.',
+    image: asset('template-site-2.png'),
+    imageAlt: 'Modern wedding website template preview',
+    hrefs: { signedOut: '/templates', signedIn: '/dashboard/builder' },
   },
   {
-    title: 'Real, but not carrying the launch claim',
-    badge: 'Should ship',
-    tone: 'should',
-    items: [
-      'Archive mode, guest photo return paths, and post-wedding memory layers',
-      'Name-change planning support after the wedding',
-      'Surrounding retention ideas that should stay smaller than the wedding-core promise',
-    ],
+    title: 'The guest list becomes the source of truth',
+    body: 'RSVPs, households, meal notes, reminders, and seating all stay attached to the same people.',
+    image: asset('product-prototype.png'),
+    imageAlt: 'dayof product dashboard preview',
+    hrefs: { signedOut: '/features/guests', signedIn: '/dashboard/guests' },
   },
   {
-    title: 'Not part of the current promise',
-    badge: 'Cut from promise',
-    tone: 'cut',
-    items: [
-      'External custom domains as a default launch expectation',
-      'Advanced analytics as a major product claim',
-      'Fake one-click automation language around migration, reminders, or merchant sync',
-    ],
+    title: 'The day-of handoff is part of the product',
+    body: 'Coordinator context, photo collection, updates, and after-wedding tasks do not fall into a separate pile.',
+    image: asset('wedding-detail-2.png'),
+    imageAlt: 'Wedding memory and planning detail',
+    hrefs: { signedOut: '/product', signedIn: '/dashboard/coordinator' },
   },
+] as const;
+
+const featureLinks = [
+  {
+    title: 'Guests + households',
+    icon: Users,
+    bullets: ['Imports', 'Households', 'Plus-one rules', 'Planner-safe exports'],
+    hrefs: { signedOut: '/features/guests', signedIn: '/dashboard/guests' },
+  },
+  {
+    title: 'RSVP engine',
+    icon: CheckCircle2,
+    bullets: ['Private links', 'Event-level replies', 'Meal choices', 'Deadline clarity'],
+    hrefs: { signedOut: '/features/rsvp', signedIn: '/dashboard/rsvp-board' },
+  },
+  {
+    title: 'Messaging',
+    icon: Mail,
+    bullets: ['Guest segments', 'Drafts', 'Scheduled updates', SITE_TRUST_COPY.reviewBeforeSendMessaging],
+    hrefs: { signedOut: '/features/messaging', signedIn: '/dashboard/messages' },
+  },
+  {
+    title: 'Travel + itinerary',
+    icon: Calendar,
+    bullets: ['Weekend schedule', 'Travel notes', 'Venue details', 'Guest-safe directions'],
+    hrefs: { signedOut: '/features/travel', signedIn: '/dashboard/itinerary' },
+  },
+  {
+    title: 'Registry',
+    icon: Heart,
+    bullets: ['Gift links', 'Funds', 'Thank-you notes', 'Clean public view'],
+    hrefs: { signedOut: '/features/registry', signedIn: '/dashboard/registry' },
+  },
+  {
+    title: 'Seating',
+    icon: Users,
+    bullets: ['Per-event layouts', 'Seat lookup', 'Catering exports', 'Check-in context'],
+    hrefs: { signedOut: '/features/seating', signedIn: '/dashboard/seating' },
+  },
+  {
+    title: 'Photo flow',
+    icon: Camera,
+    bullets: ['No-app uploads', 'Guestbook', 'Recap path', 'Album organization'],
+    hrefs: { signedOut: '/product', signedIn: '/dashboard/photos' },
+  },
+  {
+    title: 'Day-of view',
+    icon: Radio,
+    bullets: ['Coordinator mode', 'Guest lookup', 'Timeline focus', 'Issue follow-up'],
+    hrefs: { signedOut: '/product', signedIn: '/dashboard/coordinator' },
+  },
+] as const;
+
+const guestSteps = [
+  ['Open one wedding link', 'No app or account required for the public guest path.'],
+  ['Reply and update details', 'RSVP, meal notes, contact changes, and event visibility stay grounded in the same guest record.'],
+  ['Use it during the weekend', 'Travel, schedule, photo upload, and latest updates remain easy to find from a phone.'],
+  ['Come back after', 'Guestbook notes, photo recap, and vault moments keep the wedding from disappearing into old texts.'],
+] as const;
+
+const templateCards = [
+  { name: 'Garden weekend', image: asset('template-site-1.png') },
+  { name: 'Modern celebration', image: asset('template-site-2.png') },
+  { name: 'Classic estate', image: asset('template-site-3.png') },
+  { name: 'Evening reception', image: asset('template-site-4.png') },
+] as const;
+
+const trustPoints = [
+  'Private editing before sharing.',
+  'Guest access truth stays visible.',
+  'Texts stay locked until sender setup is connected.',
+  'Messages stay editable before send.',
+  'Auto-renew stays off by default.',
 ] as const;
 
 export const Home: React.FC = () => {
   const navigate = useNavigate();
   const { signIn, user } = useAuth();
   const { toast } = useToast();
-  const [expandedFaq, setExpandedFaq] = useState<number | null>(0);
-  const [demoLoading, setDemoLoading] = useState(false);
-  const proposalImageUrl = `${import.meta.env.BASE_URL}7641B308-4D92-48B2-8332-E6AB193A128D_1_105_c.jpeg`;
-  const [selectedFeature, setSelectedFeature] = useState('guests');
-  const featureRefs = useRef<Record<string, HTMLDivElement | null>>({});
-  const carouselRef = useRef<HTMLDivElement | null>(null);
-  const autoScrollPauseUntilRef = useRef(0);
+  const [demoLoading, setDemoLoading] = React.useState(false);
 
-  const featurePanels = [
-    {
-      id: 'guests',
-      title: 'Guests + Households',
-      icon: Users,
-      href: user ? '/dashboard/guests' : '/features/guests',
-      bullets: ['Household grouping', 'Plus-one rules', 'Event access', 'CSV import', 'Duplicate prevention', 'Export for vendors'],
-    },
-    {
-      id: 'rsvp',
-      title: 'RSVP Engine',
-      icon: CheckCircle2,
-      href: user ? '/dashboard/rsvp-board' : '/features/rsvp',
-      bullets: ['Multi-event RSVP', 'Household-aware flow', 'Meal selection', 'Dietary updates', 'Deadline handling', 'Response tracking view'],
-    },
-    {
-      id: 'messaging',
-      title: 'Messaging',
-      icon: Mail,
-      href: user ? '/dashboard/messages' : '/features/messaging',
-      bullets: ['Email included (fair-use)', 'Guest segmentation', 'Schedule sends', 'Delivery status updates', 'Draft + scheduled send flow', SITE_TRUST_COPY.reviewBeforeSendMessaging],
-    },
-    {
-      id: 'planner',
-      title: 'Planner Collaboration',
-      icon: Calendar,
-      href: user ? '/dashboard/planning' : '/product',
-      bullets: ['Invite your planner from the couple side', 'Named planner invite with role preset', 'Planner coordination view', 'Shared guest + seating + timeline context', 'Read-only or operational access', 'Built for real event-day help'],
-    },
-    {
-      id: 'dayof',
-      title: 'Day-of Coordination',
-      icon: Radio,
-      href: user ? '/dashboard/coordinator' : '/product',
-      bullets: ['Coordinator workspace', 'Check-in and arrivals focus', 'Timeline + Q&A context', 'Fast guest lookup', 'Alert and issue visibility', 'Built for calmer event-week execution'],
-    },
-    {
-      id: 'travel',
-      title: 'Travel + Itinerary',
-      icon: Hotel,
-      href: user ? '/dashboard/itinerary' : '/features/travel',
-      bullets: ['Hotel room blocks', 'Multi-day timeline', 'Venue addresses', 'Add-to-calendar', 'Timezone support', 'Travel FAQs'],
-    },
-    {
-      id: 'registry',
-      title: 'Registry',
-      icon: Heart,
-      href: user ? '/dashboard/registry' : '/features/registry',
-      bullets: ['Link existing registries', 'Major-registry-friendly links', 'Honeymoon fund', 'Charity donations', 'Simple gift cards and links', 'No sponsored clutter'],
-    },
-    {
-      id: 'seating',
-      title: 'Seating',
-      icon: Calendar,
-      href: user ? '/dashboard/seating' : '/features/seating',
-      bullets: ['Drag-and-drop seating board', 'Table capacity management', 'Auto-assign starting point', 'Table assignment workflows', 'Export for caterer', 'Per-event seating'],
-    },
-  ] as const;
-
-  const handleSignUp = async () => {
+  const handleSignUp = () => {
     if (user) {
       navigate('/dashboard/builder');
       return;
     }
-
     navigate('/signup');
   };
 
   const handleDemoLogin = async () => {
+    if (demoLoading) return;
     if (user) {
       navigate('/dashboard/overview');
       return;
     }
 
-    if (demoLoading) return;
     setDemoLoading(true);
     try {
       await signIn();
-      // Ensure auth context state is committed before protected-route evaluation.
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      navigate('/dashboard/overview', { replace: true });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Demo login failed. Please try again.';
-      toast(message, 'error');
+      navigate('/dashboard/overview');
+    } catch {
+      toast('Couldn’t open the demo right now. Please try again.', 'error');
       setDemoLoading(false);
     }
   };
 
-  const focusFeature = (id: string) => {
-    setSelectedFeature(id);
-    autoScrollPauseUntilRef.current = Date.now() + 2200;
-
-    const node = carouselRef.current;
-    const target = featureRefs.current[id];
-    if (!node || !target) return;
-
-    const left = target.offsetLeft - (node.clientWidth - target.clientWidth) / 2;
-    node.scrollTo({ left: Math.max(0, left), behavior: 'smooth' });
-  };
-
-  const scrollCarouselBy = (dir: 'left' | 'right') => {
-    const node = carouselRef.current;
-    if (!node) return;
-    autoScrollPauseUntilRef.current = Date.now() + 1800;
-    const amount = Math.max(280, Math.floor(node.clientWidth * 0.72));
-    node.scrollBy({ left: dir === 'left' ? -amount : amount, behavior: 'smooth' });
-  };
-
-  useEffect(() => {
-    const node = carouselRef.current;
-    if (!node) return;
-
-    const speedPx = 1; // perceptible slow drift
-    const timer = window.setInterval(() => {
-      if (Date.now() < autoScrollPauseUntilRef.current) return;
-
-      const el = carouselRef.current;
-      if (!el) return;
-      const max = el.scrollWidth - el.clientWidth;
-      if (max <= 0) return;
-
-      const next = el.scrollLeft + speedPx;
-      el.scrollLeft = next >= max ? 0 : next;
-    }, 24);
-
-    return () => window.clearInterval(timer);
-  }, []);
+  const signedInFeatureHref = (signedOut: string, signedIn: string) => (user ? signedIn : signedOut);
 
   return (
-    <div className="min-h-screen flex flex-col bg-paper text-ink">
+    <div className="min-h-screen bg-paper text-ink">
       <Header />
 
-      {/* HERO */}
-      <section id="top" className="py-14 md:py-20 bg-gradient-to-b from-paper to-white">
-        <div className="container-custom">
-          <div className="max-w-4xl mx-auto text-center">
-            <HeroReveal>
-              <h1 className="text-[2.4rem] md:text-[4rem] font-serif font-bold text-ink mb-5 leading-[1.04] updates-tight">
-                A calmer wedding operating system.
-              </h1>
-            </HeroReveal>
-            <HeroReveal delay={0.1}>
-              <p className="text-[1.0625rem] md:text-[1.1875rem] text-ink/75 mb-8 leading-relaxed max-w-3xl mx-auto">
-                Build the wedding site, manage the guest list, run RSVP and messages, collect photos, and hand the day-of details to the right people from one place.
-              </p>
-            </HeroReveal>
-            <HeroReveal delay={0.2}>
-              <div className="flex flex-col sm:flex-row gap-3 justify-center mb-6 w-full max-w-xl mx-auto px-1 sm:px-0">
-                <button
-                className="w-full sm:w-auto min-h-[52px] px-7 py-3.5 bg-brand text-paper font-semibold rounded-2xl hover:bg-brand/90 transition-all shadow-sm hover:shadow-md active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2"
-                onClick={handleSignUp}
-                aria-label={user ? 'Review your wedding site draft' : 'Start your wedding site draft'}
-              >
-                {user ? 'Review your draft' : 'Start your draft'}
-              </button>
-              <Link
-                to={user ? '/dashboard/builder' : '/templates'}
-                className="group inline-flex w-full sm:w-auto min-h-[52px] items-center justify-center gap-2 px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-2xl hover:bg-brand/5 hover:border-brand transition-all active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2"
-              >
-                {user ? 'Open your builder' : 'Browse templates'}
-                <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
-              </Link>
-              <button
-                onClick={user ? () => navigate('/dashboard/guests') : handleDemoLogin}
-                disabled={demoLoading}
-                className="inline-flex w-full sm:w-auto min-h-[52px] items-center justify-center gap-2 px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-2xl hover:bg-brand/5 hover:border-brand transition-all active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 disabled:opacity-60 disabled:cursor-wait"
-              >
-                {demoLoading && (
-                  <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
-                  </svg>
-                )}
-                {user ? 'Open your guest list' : demoLoading ? 'Opening demo...' : 'Try demo'}
-              </button>
-              </div>
-            </HeroReveal>
-            <HeroReveal delay={0.3}>
-              <p className="text-[0.8125rem] text-ink/60 updates-wide leading-loose">
-                $49 flat fee for 2 years • Auto-renew OFF by default • Hidden from search by default
-              </p>
-            </HeroReveal>
-            <HeroReveal delay={0.38}>
-              <div className="mt-4 inline-flex flex-wrap justify-center gap-2">
-                <span className="text-[11px] px-2.5 py-1 rounded-full border border-brand/20 bg-brand/5 text-brand">Beautiful site + RSVP + guest tools</span>
-                <span className="text-[11px] px-2.5 py-1 rounded-full border border-border bg-surface text-ink/80">Planner + coordinator support stays bounded by proof-backed role checks</span>
-                <span className="text-[11px] px-2.5 py-1 rounded-full border border-border bg-surface text-ink/80">No forced upsells</span>
-                <span className="text-[11px] px-2.5 py-1 rounded-full border border-border bg-surface text-ink/80">Built for guests of all ages</span>
-                <span className="text-[11px] px-2.5 py-1 rounded-full border border-border bg-surface text-ink/80">Easy if you're moving off Zola, Joy, or The Knot</span>
-              </div>
-            </HeroReveal>
-          </div>
-        </div>
-      </section>
-
-
-      <section className="section-shell bg-white border-y border-border-subtle">
-        <div className="container-custom max-w-6xl">
-          <div className="rounded-2xl border border-border-subtle bg-surface p-6 md:p-7">
-            <p className="text-xs uppercase tracking-wide text-brand font-semibold">Migration proof</p>
-            <h2 className="text-2xl md:text-3xl font-serif font-bold text-ink mt-2">One place for the details, people, and memories that matter.</h2>
-            <p className="mt-3 max-w-3xl text-ink/75">DayOf now has a guided migration path with source intake, setup guidance, guest import review, story/event/FAQ recovery helpers, registry-link carryover, and starter-draft review cues before anything gets shared with guests.</p>
-            <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-3">
-              <div className="rounded-xl border border-border-subtle bg-white p-4">
-                <p className="text-sm font-medium text-ink">Import with review truth</p>
-                <p className="mt-1 text-sm text-ink/70">Imports now show weaker mappings, duplicate names, and risky household merges instead of pretending everything is perfect.</p>
-              </div>
-              <div className="rounded-xl border border-border-subtle bg-white p-4">
-                <p className="text-sm font-medium text-ink">Recover the essentials first</p>
-                <p className="mt-1 text-sm text-ink/70">Story, event details, FAQs, and registry links have a calmer recovery path instead of forcing a total rebuild.</p>
-              </div>
-              <div className="rounded-xl border border-border-subtle bg-white p-4">
-                <p className="text-sm font-medium text-ink">Guided, not fake-automated</p>
-                <p className="mt-1 text-sm text-ink/70">The current migration path is intentionally guided and review-heavy, not a dishonest one-click import claim.</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="section-shell bg-white border-y border-border-subtle">
-        <div className="container-custom max-w-5xl">
-          <div className="rounded-2xl border border-border-subtle bg-surface p-6 md:p-7">
-            <div className="max-w-3xl">
-              <p className="text-xs uppercase tracking-wide text-brand font-semibold">Switching is part of the plan</p>
-              <h2 className="text-2xl md:text-3xl font-serif font-bold text-ink mt-2">Built for launch truth, not wedding-tech theater.</h2>
-              <p className="mt-3 text-ink/75 leading-relaxed">You should not have to restart from scratch just because another wedding site got messy, expensive, or too limited. DayOf is being shaped to make switching feel calm: keep your guest list, bring over the essentials, and move into a cleaner operating flow.</p>
-            </div>
-            <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-3">
-              <div className="rounded-xl border border-border bg-white p-4">
-                <p className="font-semibold text-ink">Bring the important parts</p>
-                <p className="mt-1 text-sm text-ink/70">Guest lists, core wedding details, and site direction matter more than rebuilding everything manually.</p>
-              </div>
-              <div className="rounded-xl border border-border bg-white p-4">
-                <p className="font-semibold text-ink">Keep the site beautiful</p>
-                <p className="mt-1 text-sm text-ink/70">Switching should not mean downgrading the site quality couples are working toward.</p>
-              </div>
-              <div className="rounded-xl border border-border bg-white p-4">
-                <p className="font-semibold text-ink">Land in a better ops flow</p>
-                <p className="mt-1 text-sm text-ink/70">Move straight into RSVPs, messages, seating, and day-of coordination without duct tape.</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* WHY I BUILT THIS */}
-      <section id="why" className="section-shell bg-white">
-        <div className="container-custom">
-          <Reveal className="max-w-3xl mx-auto">
-            <h2 className="section-title mb-10 text-center">
-              Most wedding websites stop at publish. dayof stays useful through the rest.
-            </h2>
-
-            <div className="mb-10">
-              <img
-                src={proposalImageUrl}
-                alt="Proposal moment in a park overlooking the city"
-                loading="lazy"
-                className="w-full rounded-2xl shadow-lg mb-8 object-cover"
-              />
-              <div className="space-y-5 max-w-2xl mx-auto">
-                <p className="text-[1.0625rem] text-ink/80 leading-relaxed">
-                  I got engaged this year and tried to make a wedding website like most couples do.
+      <main id="top">
+        <section className="relative min-h-[calc(74vh-64px)] overflow-hidden bg-ink text-white">
+          <img
+            src={asset('proposal.jpeg')}
+            alt=""
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+          <div className="absolute inset-0 bg-black opacity-60" />
+          <div className="container-custom relative flex min-h-[calc(74vh-64px)] flex-col justify-center pb-8 pt-20 md:pb-10 md:pt-24">
+            <div className="max-w-4xl">
+              <HeroReveal>
+                <p className="text-sm font-medium text-white opacity-80">dayof</p>
+              </HeroReveal>
+              <HeroReveal delay={0.08}>
+                <h1 className="mt-4 max-w-4xl text-[2.75rem] font-semibold leading-[1] text-white md:text-[5rem]">
+                  A calmer wedding operating system.
+                </h1>
+              </HeroReveal>
+              <HeroReveal delay={0.16}>
+                <p className="mt-6 max-w-2xl text-lg leading-relaxed text-white opacity-90 md:text-xl">
+                  Build the wedding site, manage the guest list, run RSVP and messages, collect photos, and hand the day-of details to the right people from one place.
                 </p>
-                <p className="text-[1.0625rem] text-ink/80 leading-relaxed">
-                  What I ran into was constant upsells. Basic features were locked behind confusing tiers, and simple tasks kept turning into checkout screens. It added stress at the exact moment I needed things to feel simple.
-                </p>
-                <p className="text-[1.0625rem] text-ink/80 leading-relaxed">
-                  So I built my own site and spent a lot of time getting it right.
-                </p>
-                <p className="text-[1.0625rem] text-ink/80 leading-relaxed">
-                  Then the QR code I was using stopped working. Guests couldn't access the site, and the only way to turn it back on was to pay $120 for three months.
-                </p>
-                <p className="text-[1.0625rem] text-ink/80 leading-relaxed">
-                  That experience is why this exists. A wedding site should be reliable, straightforward, and honest about pricing. No tricks. No surprise renewals. No stress tax.
-                </p>
-              </div>
-            </div>
-
-            <div className="bg-accent/5 rounded-2xl p-7 border border-accent/20 max-w-2xl mx-auto">
-              <h3 className="text-[1.5rem] font-serif font-bold text-ink mb-3 leading-[1.2] updates-tight">Built for trust, not pressure</h3>
-              <p className="text-[1.0625rem] text-ink/80 mb-6 leading-relaxed">Your wedding website should feel calm, polished, and straightforward from the start.</p>
-              <ul className="space-y-3 text-[0.9375rem] text-ink/70">
-                <li className="leading-relaxed">No upsells. No paid add ons to "unlock" the basics.</li>
-                <li className="leading-relaxed">No rigged registry order. No forced affiliate links.</li>
-                <li className="leading-relaxed">No QR codes or links that break unless you keep paying.</li>
-                <li className="leading-relaxed">No surprise renewals. Auto renew is off by default.</li>
-                <li className="leading-relaxed">No hidden fees. Clear pricing before you pay.</li>
-                <li className="leading-relaxed">Privacy first defaults, so your details are not accidentally public.</li>
-              </ul>
-            </div>
-          </Reveal>
-        </div>
-      </section>
-
-      {/* FEATURES */}
-      <section id="features" className="section-shell bg-paper">
-        <div className="container-custom">
-          <SlideReveal from="left" className="section-intro">
-            <h2 className="section-title mb-4">
-              Site, guests, and day-of work in the same rhythm.
-            </h2>
-            <p className="text-ink/70 max-w-3xl">
-              DayOf should be judged on the core wedding path couples actually need right now. Some surrounding slices are real direction, but they should not blur the current v1 line.
-            </p>
-          </SlideReveal>
-
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-8">
-            {V1_HOME_GROUPS.map((group) => {
-              const toneClasses = group.tone === 'must'
-                ? 'border-emerald-200 bg-white'
-                : group.tone === 'should'
-                  ? 'border-amber-200 bg-white'
-                  : 'border-rose-200 bg-white';
-              const badgeClasses = group.tone === 'must'
-                ? 'bg-emerald-50 text-emerald-700'
-                : group.tone === 'should'
-                  ? 'bg-amber-50 text-amber-700'
-                  : 'bg-rose-50 text-rose-700';
-
-              return (
-                <div key={group.title} className={`rounded-2xl border p-5 ${toneClasses}`}>
-                  <div className="flex items-center justify-between gap-3 mb-3">
-                    <h3 className="font-semibold text-ink">{group.title}</h3>
-                    <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClasses}`}>{group.badge}</span>
-                  </div>
-                  <ul className="space-y-2 text-sm text-ink/80">
-                    {group.items.map((item) => (
-                      <li key={item} className="flex items-start gap-2">
-                        <span className="text-brand mt-0.5">•</span>
-                        <span>{item}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              );
-            })}
-          </div>
-
-          <div className="mb-8 sticky top-20 z-10">
-            <div className="bg-white/90 backdrop-blur border border-border-subtle rounded-2xl p-2 overflow-x-auto">
-              <div className="flex gap-2 min-w-max">
-                {featurePanels.map((feature) => (
+              </HeroReveal>
+              <HeroReveal delay={0.24}>
+                <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                   <button
-                    key={feature.id}
-                    type="button"
-                    onClick={() => focusFeature(feature.id)}
-                    className={`px-4 py-2.5 rounded-xl border text-sm font-semibold transition-all whitespace-nowrap ${selectedFeature === feature.id
-                      ? 'bg-brand text-paper border-brand shadow-sm'
-                      : 'bg-white text-ink/80 border-border hover:border-brand/40 hover:bg-brand/5'}`}
+                    onClick={handleSignUp}
+                    aria-label={user ? 'Continue your wedding site' : 'Start your wedding site draft'}
+                    className="inline-flex min-h-[54px] items-center justify-center rounded-xl bg-white px-7 py-3.5 text-base font-semibold text-ink transition hover:bg-paper"
                   >
-                    {feature.title}
+                    {user ? 'Continue your site' : 'Start your draft'}
                   </button>
+                  <Link
+                    to="/templates"
+                    className="inline-flex min-h-[54px] items-center justify-center gap-2 rounded-xl border border-white/35 bg-white/10 px-7 py-3.5 text-base font-semibold text-white transition hover:bg-white/18"
+                  >
+                    View templates
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                  {DEMO_MODE ? (
+                    <button
+                      onClick={handleDemoLogin}
+                      disabled={demoLoading}
+                      className="inline-flex min-h-[54px] items-center justify-center rounded-xl border border-white/25 bg-[#2d2d2d]/35 px-7 py-3.5 text-base font-semibold text-white transition hover:bg-[#2d2d2d]/55 disabled:cursor-wait disabled:opacity-70"
+                    >
+                      {demoLoading ? 'Opening demo...' : 'View demo'}
+                    </button>
+                  ) : null}
+                </div>
+              </HeroReveal>
+            </div>
+
+            <HeroReveal delay={0.32}>
+              <div className="mt-9 grid border-y border-white/24 md:grid-cols-3">
+                {heroStats.map(([label, body]) => (
+                  <div key={label} className="border-white/20 py-4 md:border-r md:px-5 md:last:border-r-0">
+                    <p className="text-sm font-semibold text-white">{label}</p>
+                    <p className="mt-1 text-sm leading-relaxed text-white opacity-75">{body}</p>
+                  </div>
                 ))}
               </div>
+            </HeroReveal>
+          </div>
+        </section>
+
+        <section id="why" className="border-b border-border-subtle bg-white py-12 md:py-16">
+          <div className="container-custom grid gap-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-end">
+            <div>
+              <Reveal>
+                <p className="text-sm font-medium text-brand">Why this exists</p>
+                <h2 className="mt-3 max-w-3xl text-3xl font-semibold leading-tight text-ink md:text-5xl">
+                  Most wedding websites stop at publish. dayof stays useful through the rest.
+                </h2>
+              </Reveal>
             </div>
+            <Reveal delay={0.08}>
+              <div className="max-w-2xl space-y-4 text-base leading-relaxed text-ink/72">
+                <p>
+                  Couples do not just need a beautiful page. They need guest answers, private links, message drafts, seating context, travel clarity, photo collection, and a way to keep helpers aligned without turning the wedding into a spreadsheet job.
+                </p>
+                <p>
+                  dayof keeps the public experience polished while the operational pieces stay close enough to actually help.
+                </p>
+              </div>
+            </Reveal>
           </div>
+        </section>
 
-          <div className="mb-3 flex items-center justify-end gap-2">
-            <button
-              type="button"
-              onClick={() => scrollCarouselBy('left')}
-              className="px-3 py-1.5 rounded-lg border border-border bg-white text-ink/80 hover:text-brand hover:border-brand/40"
-              aria-label="Scroll features left"
-            >
-              ‹
-            </button>
-            <button
-              type="button"
-              onClick={() => scrollCarouselBy('right')}
-              className="px-3 py-1.5 rounded-lg border border-border bg-white text-ink/80 hover:text-brand hover:border-brand/40"
-              aria-label="Scroll features right"
-            >
-              ›
-            </button>
-          </div>
+        <section className="bg-paper py-12 md:py-20">
+          <div className="container-custom">
+            <Reveal>
+              <div className="max-w-3xl">
+                <p className="text-sm font-medium text-brand">Product shape</p>
+                <h2 className="mt-3 text-3xl font-semibold leading-tight text-ink md:text-5xl">
+                  Site, guests, and day-of work in the same rhythm.
+                </h2>
+              </div>
+            </Reveal>
 
-          <div ref={carouselRef} className="mb-10 overflow-x-auto pb-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            <div className="flex gap-4 min-w-max pr-2">
-            {featurePanels.map((feature, idx) => {
-              const Icon = feature.icon;
-              return (
-                <SlideReveal key={feature.id} from={idx % 2 === 0 ? 'left' : 'right'}>
-                  <div
-                    ref={(el) => {
-                      featureRefs.current[feature.id] = el;
-                    }}
-                    className={`shrink-0 w-[90vw] sm:w-[82vw] md:w-[62vw] lg:w-[48vw] rounded-2xl border p-5 md:p-7 transition-all ${selectedFeature === feature.id
-                      ? 'bg-white border-brand/35 shadow-lg'
-                      : 'bg-white/80 border-border-subtle shadow-sm'}`}
-                  >
-                    <div className="flex items-start justify-between gap-4 mb-5">
-                      <div className="flex items-center gap-3">
-                        <div className={`p-3 rounded-xl ${selectedFeature === feature.id ? 'bg-brand/12' : 'bg-brand/8'}`}>
-                          <Icon className="w-6 h-6 text-brand" />
-                        </div>
-                        <h3 className="text-[1.3rem] font-serif font-bold text-ink leading-snug updates-tight">{feature.title}</h3>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => focusFeature(feature.id)}
-                        className="text-xs font-semibold px-3 py-2 rounded-lg border border-border hover:border-brand/50 text-ink/70 hover:text-brand bg-white"
-                      >
-                        Focus
-                      </button>
-                    </div>
-
-                    <ul className="grid grid-cols-1 md:grid-cols-2 gap-2.5 text-[0.92rem] text-ink/75 leading-relaxed">
-                      {feature.bullets.map((bullet) => (
-                        <li key={bullet} className="flex items-start gap-2">
-                          <span className="text-brand mt-0.5">•</span>
-                          <span>{bullet}</span>
-                        </li>
-                      ))}
-                    </ul>
-
-                    <div className="mt-5">
+            <div className="mt-9 grid gap-5 lg:grid-cols-3">
+              {operatingSystemRows.map((item, index) => (
+                <Reveal key={item.title} delay={0.08 * index}>
+                  <article className="overflow-hidden rounded-xl border border-border-subtle bg-white shadow-sm">
+                    <img src={item.image} alt={item.imageAlt} className="aspect-[4/3] w-full object-cover" />
+                    <div className="p-5">
+                      <h3 className="text-xl font-semibold text-ink">{item.title}</h3>
+                      <p className="mt-3 text-sm leading-relaxed text-ink/70">{item.body}</p>
                       <Link
-                        to={feature.href}
-                        className="group inline-flex items-center gap-2 text-sm font-semibold text-brand hover:text-brand/85"
+                        to={signedInFeatureHref(item.hrefs.signedOut, item.hrefs.signedIn)}
+                        aria-label="Explore this feature"
+                        className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-brand"
                       >
                         Explore this feature
-                        <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
+                        <ArrowRight className="h-4 w-4" />
                       </Link>
                     </div>
-                  </div>
-                </SlideReveal>
-              );
-            })}
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-amber-200 bg-amber-50/60 p-5 md:p-6 mb-8">
-            <p className="text-xs uppercase tracking-wide text-amber-700 font-semibold">Adjacent, not carrying v1</p>
-            <h3 className="text-xl md:text-2xl font-serif font-bold text-ink mt-2">Post-wedding memory layers stay in the product direction bucket for now.</h3>
-            <p className="mt-3 max-w-3xl text-sm md:text-base text-ink/75">Archive mode, guest photo return paths, and name-change support can stay real without pretending they are the reason to trust DayOf first. The hard launch line is still {SITE_TRUST_COPY.launchStoryCore}.</p>
-          </div>
-
-          <SlideReveal from="right" className="text-center">
-            <Link
-              to={user ? '/dashboard/planning' : '/product'}
-              className="group inline-flex items-center justify-center gap-2 px-6 py-3 border-2 border-brand text-brand font-semibold rounded-2xl hover:bg-brand/5 transition-all active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
-            >
-              {user ? 'Open planner workspace' : 'See full product tour'}
-              <ArrowRight className="w-5 h-5 transition-transform group-hover:translate-x-0.5" />
-            </Link>
-          </SlideReveal>
-        </div>
-      </section>
-
-      {/* PRICING */}
-      <section id="pricing" className="py-14 md:py-16 bg-white">
-        <div className="container-custom">
-          <div className="text-center mb-9">
-            <h2 className="text-[2rem] font-serif font-bold text-ink mb-4 leading-[1.2] updates-tight">
-              Simple, honest pricing.
-            </h2>
-            <p className="text-[1.125rem] text-ink/70 leading-relaxed">
-              One flat fee. No surprises. Auto-renew OFF by default.
-            </p>
-          </div>
-
-          <div className="max-w-lg mx-auto mb-14">
-            <div className="bg-white border border-brand/25 rounded-2xl p-7 shadow-[0_1px_2px_rgba(15,23,42,0.06)] hover:shadow-[0_8px_24px_rgba(15,23,42,0.08)] transition-shadow duration-200">
-              <div className="text-center mb-7">
-                <h3 className="text-[1.5rem] font-serif font-bold text-ink mb-6 leading-[1.2] updates-tight">Core wedding site + ops</h3>
-                <div className="mb-5">
-                  <div className="flex items-baseline justify-center gap-2">
-                    <span className="text-[4.5rem] font-bold text-brand leading-[1] updates-tight">$49</span>
-                    <span className="text-[1.125rem] text-ink/60 leading-snug pb-2">/ 2 years</span>
-                  </div>
-                </div>
-                <span className="inline-block px-4 py-2 bg-brand/10 text-brand text-[0.8125rem] font-semibold rounded-full border border-brand/20">
-                  Auto-renew: OFF by default
-                </span>
-              </div>
-
-              <ul className="space-y-3 mb-7">
-                {[
-                  'Guest list built for real weddings',
-                  'Email included (fair-use)',
-                  'SMS credits optional',
-                  'Multi-event RSVP',
-                  'Meal choices + dietary updates',
-                  'Guest list management',
-                  'Itinerary timeline',
-                  'Hidden from search by default',
-                  'Mobile-friendly for all ages',
-                  'Guest export tools',
-                ].map((item, idx) => (
-                  <li key={idx} className="flex items-start gap-3">
-                    <CheckCircle2 className="w-5 h-5 text-success mt-0.5 flex-shrink-0" />
-                    <span className="text-[0.9375rem] text-ink/75 leading-relaxed">{item}</span>
-                  </li>
-                ))}
-              </ul>
-
-              <div className="space-y-3">
-                <button
-                  className="w-full px-6 py-4 text-[1.0625rem] bg-brand text-paper font-semibold rounded-xl hover:bg-brand/90 transition-all shadow-sm hover:shadow-md active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2"
-                  onClick={handleSignUp}
-                  aria-label={user ? 'Review your wedding site draft' : 'Start your wedding site draft'}
-                >
-                  {user ? 'Review your draft' : 'Start your draft'}
-                </button>
-                <button
-                  onClick={user ? () => navigate('/dashboard/messages') : handleDemoLogin}
-                  disabled={demoLoading}
-                  className="inline-flex items-center justify-center gap-2 w-full px-6 py-3 text-center border-2 border-brand/40 text-brand font-medium rounded-xl hover:bg-brand/5 hover:border-brand transition-all active:translate-y-[1px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/50 focus-visible:ring-offset-2 disabled:opacity-60 disabled:cursor-wait"
-                >
-                  {demoLoading && (
-                    <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
-                    </svg>
-                  )}
-                  {user ? 'Open message drafts' : demoLoading ? 'Opening demo...' : 'Try demo'}
-                </button>
-              </div>
-
-              <div className="mt-5 pt-5 border-t border-border-subtle space-y-2">
-                <p className="text-[0.8125rem] text-ink/55 text-center updates-wide leading-loose">
-                  Taxes may apply depending on location.
-                </p>
-                <p className="text-[0.8125rem] text-ink/55 text-center updates-wide leading-loose">
-                  After 2 years: site remains readable. You'll get the option to renew.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="max-w-3xl mx-auto mt-1">
-            <h3 className="text-[1.5rem] font-serif font-bold text-ink mb-6 text-center leading-[1.2] updates-tight">Frequently asked questions</h3>
-            <div className="space-y-3">
-              {[
-                {
-                  q: 'Why is auto-renew off by default?',
-                  a: 'We believe in transparency. Most couples only need the site for 2-3 years. We won\'t charge you again unless you explicitly choose to renew.',
-                },
-                {
-                  q: 'What about privacy and search engines?',
-                  a: SITE_TRUST_COPY.hiddenFromSearchExplainer,
-                },
-                {
-                  q: 'How do SMS credits work?',
-                  a: 'Email is included. For urgent updates (venue changes, weather), you can purchase SMS credits. We charge $0.02/message with no markup.',
-                },
-                {
-                  q: SITE_TRUST_COPY.customWeddingUrl,
-                  a: SITE_TRUST_COPY.customWeddingUrlExplainer,
-                },
-                {
-                  q: 'What if I need a refund?',
-                  a: 'Full refund within 30 days, no questions asked. After that, pro-rated refund based on time remaining.',
-                },
-                {
-                  q: 'Can I export my data?',
-                  a: 'Yes. DayOf supports export paths for core wedding data like guest information, RSVP records, and other practical planning data. Exact export shape depends on the part of the product, so we keep the promise tied to what couples actually need rather than pretending every surface has the same export contract.',
-                },
-                {
-                  q: 'What happens after 2 years?',
-                  a: 'Your site stays read-only. You can download everything or renew for another 2 years. We send reminders 60 and 30 days before.',
-                },
-                {
-                  q: 'Do you sell my data or show ads?',
-                  a: 'Never. We make money from the $49 flat fee. Your wedding is not our ad platform.',
-                },
-              ].map((faq, idx) => (
-                <div
-                  key={idx}
-                  className="bg-paper border border-brand/20 rounded-2xl p-5 cursor-pointer hover:border-brand/40 transition-all"
-                  onClick={() => setExpandedFaq(expandedFaq === idx ? null : idx)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      setExpandedFaq(expandedFaq === idx ? null : idx);
-                    }
-                  }}
-                  aria-expanded={expandedFaq === idx}
-                  aria-label={faq.q}
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="flex-1">
-                      <h4 className="text-[1.125rem] font-semibold text-ink mb-2 leading-snug">{faq.q}</h4>
-                      {expandedFaq === idx && (
-                        <p className="text-base text-ink/70 leading-relaxed">{faq.a}</p>
-                      )}
-                    </div>
-                    <ChevronDown
-                      className={`w-5 h-5 text-ink/60 flex-shrink-0 transition-transform ${
-                        expandedFaq === idx ? 'rotate-180' : ''
-                      }`}
-                      aria-hidden="true"
-                    />
-                  </div>
-                </div>
+                  </article>
+                </Reveal>
               ))}
             </div>
           </div>
-        </div>
-      </section>
+        </section>
+
+        <section id="features" className="border-y border-border-subtle bg-white py-12 md:py-20">
+          <div className="container-custom">
+            <div className="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
+              <Reveal>
+                <div>
+                  <p className="text-sm font-medium text-brand">What it replaces</p>
+                  <h2 className="mt-3 text-3xl font-semibold leading-tight text-ink md:text-5xl">
+                    One place for the details, people, and memories that matter.
+                  </h2>
+                  <p className="mt-4 text-base leading-relaxed text-ink/72">
+                    Keep the couple-facing tools dense and useful while keeping the guest-facing path simple.
+                  </p>
+                </div>
+              </Reveal>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                {featureLinks.map((feature, index) => {
+                  const Icon = feature.icon;
+                  return (
+                    <Reveal key={feature.title} delay={0.03 * index}>
+                      <article className="rounded-xl border border-border-subtle bg-paper p-5">
+                        <div className="flex items-center gap-3">
+                          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white text-brand">
+                            <Icon className="h-4 w-4" />
+                          </div>
+                          <h3 className="text-base font-semibold text-ink">{feature.title}</h3>
+                        </div>
+                        <ul className="mt-4 grid gap-2 text-sm text-ink/70">
+                          {feature.bullets.map((bullet) => (
+                            <li key={bullet} className="flex gap-2">
+                              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-brand" />
+                              <span>{bullet}</span>
+                            </li>
+                          ))}
+                        </ul>
+                        <Link
+                          to={signedInFeatureHref(feature.hrefs.signedOut, feature.hrefs.signedIn)}
+                          aria-label="Explore this feature"
+                          className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-brand"
+                        >
+                          Explore this feature
+                          <ArrowRight className="h-4 w-4" />
+                        </Link>
+                      </article>
+                    </Reveal>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="bg-[#f6f8f3] py-12 md:py-20">
+          <div className="container-custom grid gap-9 lg:grid-cols-[1fr_0.9fr] lg:items-center">
+            <div>
+              <Reveal>
+                <p className="text-sm font-medium text-brand">Guest experience</p>
+                <h2 className="mt-3 max-w-3xl text-3xl font-semibold leading-tight text-ink md:text-5xl">
+                  Guests should never feel like they are using planning software.
+                </h2>
+              </Reveal>
+              <Reveal delay={0.08}>
+                <p className="mt-4 max-w-2xl text-base leading-relaxed text-ink/72">
+                  They should open one link, understand what matters, reply when needed, and share memories from their phone. The complexity can stay behind the scenes.
+                </p>
+              </Reveal>
+              <div className="mt-7 grid gap-3">
+                {guestSteps.map(([title, body], index) => (
+                  <Reveal key={title} delay={0.05 * index}>
+                    <div className="grid gap-3 rounded-xl border border-border-subtle bg-white p-4 sm:grid-cols-[44px_1fr]">
+                      <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[#e8f0e4] text-sm font-semibold text-brand">
+                        {index + 1}
+                      </div>
+                      <div>
+                        <h3 className="text-base font-semibold text-ink">{title}</h3>
+                        <p className="mt-1 text-sm leading-relaxed text-ink/68">{body}</p>
+                      </div>
+                    </div>
+                  </Reveal>
+                ))}
+              </div>
+            </div>
+            <Reveal delay={0.14}>
+              <img
+                src={asset('wedding-detail-3.png')}
+                alt="Guest-facing wedding detail preview"
+                className="aspect-[4/5] w-full rounded-xl border border-border-subtle object-cover shadow-sm"
+              />
+            </Reveal>
+          </div>
+        </section>
+
+        <section id="templates" className="border-y border-border-subtle bg-white py-12 md:py-20">
+          <div className="container-custom">
+            <div className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+              <Reveal>
+                <div className="max-w-3xl">
+                  <p className="text-sm font-medium text-brand">Templates</p>
+                  <h2 className="mt-3 text-3xl font-semibold leading-tight text-ink md:text-5xl">
+                    Start with a site that already feels designed.
+                  </h2>
+                </div>
+              </Reveal>
+              <Reveal delay={0.08}>
+                <Link to="/templates" className="inline-flex min-h-[48px] items-center justify-center gap-2 rounded-xl border border-brand/25 px-5 py-3 text-sm font-semibold text-brand transition hover:bg-brand/5">
+                  View templates
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Reveal>
+            </div>
+
+            <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              {templateCards.map((card, index) => (
+                <Reveal key={card.name} delay={0.05 * index}>
+                  <Link to="/templates" className="group block overflow-hidden rounded-xl border border-border-subtle bg-paper">
+                    <img src={card.image} alt={`${card.name} wedding website preview`} className="aspect-[4/5] w-full object-cover transition duration-300 group-hover:scale-[1.02]" />
+                    <div className="flex items-center justify-between p-4">
+                      <span className="text-sm font-semibold text-ink">{card.name}</span>
+                      <ArrowRight className="h-4 w-4 text-brand" />
+                    </div>
+                  </Link>
+                </Reveal>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="bg-paper py-12 md:py-20">
+          <div className="container-custom grid gap-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+            <Reveal>
+              <div>
+                <p className="text-sm font-medium text-brand">Trust posture</p>
+                <h2 className="mt-3 text-3xl font-semibold leading-tight text-ink md:text-5xl">
+                  Built for launch truth, not wedding-tech theater.
+                </h2>
+                <p className="mt-4 text-base leading-relaxed text-ink/72">
+                  The product should be honest about what is ready, what needs setup, and what guests can actually access.
+                </p>
+              </div>
+            </Reveal>
+            <Reveal delay={0.1}>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {trustPoints.map((point) => (
+                  <div key={point} className="flex gap-3 rounded-xl border border-border-subtle bg-white p-4">
+                    <Shield className="mt-0.5 h-4 w-4 shrink-0 text-[#4D7FA3]" />
+                    <p className="text-sm leading-relaxed text-ink/72">{point}</p>
+                  </div>
+                ))}
+                <div className="rounded-xl border border-[#C89F56]/35 bg-[#fff8ea] p-4 sm:col-span-2">
+                  <p className="text-sm leading-relaxed text-ink/76">
+                    {SITE_TRUST_COPY.guestAccessTruth}
+                  </p>
+                </div>
+              </div>
+            </Reveal>
+          </div>
+        </section>
+
+        <section id="pricing" className="bg-white py-12 md:py-20">
+          <div className="container-custom grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+            <Reveal>
+              <div>
+                <p className="text-sm font-medium text-brand">Pricing</p>
+                <h2 className="mt-3 text-3xl font-semibold leading-tight text-ink md:text-5xl">
+                  Simple, honest pricing.
+                </h2>
+                <p className="mt-4 max-w-2xl text-base leading-relaxed text-ink/72">
+                  $49 flat fee for two years. Auto-renew stays off by default. You get the website, RSVP, guests, messaging, seating, registry, itinerary, photos, and day-of coordination in one place.
+                </p>
+              </div>
+            </Reveal>
+            <Reveal delay={0.1}>
+              <div className="rounded-xl border border-border-subtle bg-paper p-6">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-5xl font-semibold text-ink">$49</span>
+                  <span className="text-sm text-ink/64">for two years</span>
+                </div>
+                <ul className="mt-6 grid gap-3 text-sm text-ink/72">
+                  {['Wedding website and templates', 'Guest list, RSVP, messages, and seating', 'Photos, guestbook, registry, itinerary, and coordinator tools', 'No surprise auto-renewal'].map((item) => (
+                    <li key={item} className="flex gap-2">
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-brand" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-7 flex flex-col gap-3 sm:flex-row">
+                  <button
+                    onClick={handleSignUp}
+                    aria-label={user ? 'Continue your wedding site' : 'Start your wedding site draft'}
+                    className="inline-flex min-h-[52px] items-center justify-center rounded-xl bg-brand px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand/90"
+                  >
+                    {user ? 'Continue your site' : 'Start your draft'}
+                  </button>
+                  <Link
+                    to="/product"
+                    className="inline-flex min-h-[52px] items-center justify-center rounded-xl border border-border bg-white px-6 py-3 text-sm font-semibold text-ink transition hover:bg-paper"
+                  >
+                    Product tour
+                  </Link>
+                </div>
+              </div>
+            </Reveal>
+          </div>
+        </section>
+
+        {user && (
+          <section className="border-t border-border-subtle bg-paper py-9 md:py-12">
+            <div className="container-custom">
+              <Reveal>
+                <div className="rounded-xl border border-brand/15 bg-white p-6">
+                  <p className="text-sm font-medium text-brand">Already started?</p>
+                  <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                    <Link
+                      to="/dashboard/builder"
+                      onClick={() => navigate('/dashboard/builder')}
+                      className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-border px-5 py-3 text-sm font-semibold text-ink"
+                    >
+                      Edit your site
+                    </Link>
+                    <Link
+                      to="/dashboard/planning"
+                      className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-border px-5 py-3 text-sm font-semibold text-ink"
+                    >
+                      Continue planning
+                    </Link>
+                    <button
+                      onClick={() => navigate('/dashboard/guests')}
+                      className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-border px-5 py-3 text-sm font-semibold text-ink"
+                    >
+                      Manage guests
+                    </button>
+                    <button
+                      onClick={() => navigate('/dashboard/messages')}
+                      className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-border px-5 py-3 text-sm font-semibold text-ink"
+                    >
+                      Guest messages
+                    </button>
+                  </div>
+                </div>
+              </Reveal>
+            </div>
+          </section>
+        )}
+      </main>
 
       <Footer />
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -46,7 +46,7 @@ const operatingSystemRows = [
     body: 'Coordinator context, photo collection, updates, and after-wedding tasks do not fall into a separate pile.',
     image: asset('wedding-detail-2.png'),
     imageAlt: 'Wedding memory and planning detail',
-    hrefs: { signedOut: '/product', signedIn: '/dashboard/coordinator' },
+    hrefs: { signedOut: '/product', signedIn: '/dashboard/planning' },
   },
 ] as const;
 
@@ -187,7 +187,7 @@ export const Home: React.FC = () => {
                 <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                   <button
                     onClick={handleSignUp}
-                    aria-label={user ? 'Continue your wedding site' : 'Start your wedding site draft'}
+                    aria-label={user ? 'Review your wedding site draft' : 'Start your wedding site draft'}
                     className="inline-flex min-h-[54px] items-center justify-center rounded-xl bg-white px-7 py-3.5 text-base font-semibold text-ink transition hover:bg-paper"
                   >
                     {user ? 'Continue your site' : 'Start your draft'}
@@ -471,7 +471,7 @@ export const Home: React.FC = () => {
                 <div className="mt-7 flex flex-col gap-3 sm:flex-row">
                   <button
                     onClick={handleSignUp}
-                    aria-label={user ? 'Continue your wedding site' : 'Start your wedding site draft'}
+                    aria-label={user ? 'Review your wedding site draft' : 'Start your wedding site draft'}
                     className="inline-flex min-h-[52px] items-center justify-center rounded-xl bg-brand px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand/90"
                   >
                     {user ? 'Continue your site' : 'Start your draft'}
@@ -498,24 +498,28 @@ export const Home: React.FC = () => {
                     <Link
                       to="/dashboard/builder"
                       onClick={() => navigate('/dashboard/builder')}
+                      aria-label="Open your builder"
                       className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-border px-5 py-3 text-sm font-semibold text-ink"
                     >
                       Edit your site
                     </Link>
                     <Link
                       to="/dashboard/planning"
+                      aria-label="Open planner workspace"
                       className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-border px-5 py-3 text-sm font-semibold text-ink"
                     >
                       Continue planning
                     </Link>
                     <button
                       onClick={() => navigate('/dashboard/guests')}
+                      aria-label="Open your guest list"
                       className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-border px-5 py-3 text-sm font-semibold text-ink"
                     >
                       Manage guests
                     </button>
                     <button
                       onClick={() => navigate('/dashboard/messages')}
+                      aria-label="Open message drafts"
                       className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-border px-5 py-3 text-sm font-semibold text-ink"
                     >
                       Guest messages

--- a/src/pages/Product.test.tsx
+++ b/src/pages/Product.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEMO_MODE } from '../config/env';
 
 const navigateMock = vi.fn();
 const authState = {
@@ -12,7 +13,13 @@ vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return {
     ...actual,
-    Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,
+    Link: ({
+      children,
+      to,
+      ...props
+    }: React.PropsWithChildren<{ to: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>>) => (
+      <a href={to} {...props}>{children}</a>
+    ),
     useNavigate: () => navigateMock,
   };
 });
@@ -31,8 +38,8 @@ vi.mock('../components/layout', () => ({
 }));
 
 vi.mock('../components/marketing/Reveal', () => ({
-  HeroReveal: ({ children }: any) => <>{children}</>,
-  SlideReveal: ({ children }: any) => <>{children}</>,
+  HeroReveal: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  SlideReveal: ({ children }: React.PropsWithChildren) => <>{children}</>,
 }));
 
 import { Product } from './Product';
@@ -118,12 +125,12 @@ describe('Product starter draft truth', () => {
     authState.user = { id: 'user-1' };
     render(<Product />);
 
-    expect(screen.getAllByRole('button', { name: 'Review your draft' }).length).toBe(2);
+    expect(screen.getAllByRole('button', { name: 'Review your draft' }).length).toBeGreaterThan(0);
     expect(screen.queryByRole('button', { name: 'Start your draft' })).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Open your builder' }).length).toBe(3);
-    expect(screen.getByText('Ready to keep shaping your draft?')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Open your builder' }).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Ready to keep shaping your (draft|wedding)\?/i)).toBeInTheDocument();
     expect(screen.queryByText('Want to see the full flow in action?')).not.toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'open your builder' })).toHaveAttribute('href', '/dashboard/builder');
+    expect(screen.getAllByRole('button', { name: 'Open your builder' })[0]).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Try full demo' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Open your dashboard' })).not.toBeInTheDocument();
 
@@ -143,9 +150,15 @@ describe('Product starter draft truth', () => {
   it('keeps the product demo banner in demo mode for signed-out visitors', () => {
     render(<Product />);
 
-    expect(screen.getByText('Want to see the full flow in action?')).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Try product demo' }).length).toBe(2);
-    expect(screen.getByRole('button', { name: 'Try full demo' })).toBeInTheDocument();
+    if (DEMO_MODE) {
+      expect(screen.getByText('Want to see the full flow in action?')).toBeInTheDocument();
+      expect(screen.getAllByRole('button', { name: 'Try product demo' }).length).toBe(2);
+      expect(screen.getByRole('button', { name: 'Try full demo' })).toBeInTheDocument();
+    } else {
+      expect(screen.queryByText('Want to see the full flow in action?')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Try product demo' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Try full demo' })).not.toBeInTheDocument();
+    }
     expect(screen.queryByRole('button', { name: 'Open your dashboard' })).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'See collaboration trust notes' })).toHaveAttribute('href', '/trust');
     expect(screen.getByRole('link', { name: 'browse templates' })).toHaveAttribute('href', '/templates');

--- a/src/pages/Product.tsx
+++ b/src/pages/Product.tsx
@@ -4,6 +4,7 @@ import { Header, Footer } from '../components/layout';
 import { useAuth } from '../hooks/useAuth';
 import { useToast } from '../components/ui/Toast';
 import { SITE_TRUST_COPY } from '../lib/siteTrustCopy';
+import { DEMO_MODE } from '../config/env';
 import { ArrowRight, Calendar, CheckCircle2, Mail, Shield, Users, Wallet } from 'lucide-react';
 import { SlideReveal } from '../components/marketing/Reveal';
 
@@ -20,10 +21,10 @@ type Step = {
 const STEPS: Step[] = [
   { id: 'launch', title: 'Build a site draft you’ll be proud to share', kicker: 'Step 1', outcome: SITE_TRUST_COPY.privateEditing, detail: `Start with a strong template, clear setup, and ${SITE_TRUST_COPY.draftToLaunch.toLowerCase()}` },
   { id: 'guests', title: 'Organize guests + households', kicker: 'Step 2', outcome: 'Know who is invited and where they belong.', detail: 'Households, plus-ones, and statuses in one place.' },
-  { id: 'rsvp', title: 'Collect RSVPs cleanly', kicker: 'Step 3', outcome: 'Get responses without confusion.', detail: 'Event-level RSVP and meal tracking without hacks.' },
+  { id: 'rsvp', title: 'Collect RSVPs cleanly', kicker: 'Step 3', outcome: 'Get responses without confusion.', detail: 'Event-level RSVP and meal tracking without awkward workarounds.' },
   { id: 'message', title: 'Message everyone', kicker: 'Step 4', outcome: 'Review the right update before sending it to the right group.', detail: 'Stop copy/pasting from spreadsheets to email tools while keeping send decisions in your hands.' },
-  { id: 'seating', title: 'Run seating + timeline', kicker: 'Step 5', outcome: 'Plan execution without doc chaos.', detail: 'Keep tables and event flow aligned in one view.' },
-  { id: 'dayof', title: 'Execute day-of', kicker: 'Step 6', outcome: 'Fewer surprises on event day.', detail: 'Use one calmer coordination view instead of juggling a pile of tabs.' },
+  { id: 'seating', title: 'Run seating + timeline', kicker: 'Step 5', outcome: 'Plan the room and the day in one clear place.', detail: 'Keep tables and event flow aligned in one view.' },
+  { id: 'dayof', title: 'Plan day-of', kicker: 'Step 6', outcome: 'Fewer surprises on event day.', detail: 'Use one calmer coordination view instead of juggling a pile of tabs.' },
 ];
 
 const FEATURE_AUDIT_GROUPS = [
@@ -36,32 +37,32 @@ const FEATURE_AUDIT_GROUPS = [
     items: ['Guest households + plus-ones', 'Multi-event RSVP + meal tracking', 'Itinerary + travel details', 'Seating planner + lookup', 'Registry links + gifting'],
   },
   {
-    title: 'Operations',
-    items: ['Guest messaging', 'Planner coordination view', 'Coordinator mode', 'Dashboard overview', 'Planning workspace', 'Settings + preferences'],
+    title: 'Planning tools',
+    items: ['Guest messaging', 'Planner access', 'Day-of view', 'Wedding home', 'Planning space', 'Settings + preferences'],
   },
   {
-    title: 'Adjacent, not carrying v1',
+    title: 'Helpful extras',
     items: ['Photo upload page', 'Guest memory collection', 'Archive mode foundation', 'Name-change support after the wedding'],
   },
 ] as const;
 
 const V1_STATUS_GROUPS = [
   {
-    title: 'Core v1 today',
+    title: 'Core experience today',
     tone: 'must',
-    intro: 'This is the product line DayOf should actually be judged on right now.',
+    intro: 'This is the core experience dayof should be judged on right now.',
     items: [
       'Build a polished wedding site draft with honest privacy + access controls before sharing it with guests',
       'Run guest list, households, RSVP, meals, and event invites in one place',
-      'Handle core wedding messaging without spreadsheet-to-email-tool chaos',
+      'Handle core wedding messaging without bouncing between spreadsheets and email tools',
       'Use seating, itinerary, and coordination views to run the event week calmly',
-      'Invite a planner or coordinator into a role-aware workspace',
+      'Invite a planner or coordinator into a role-aware planning space',
     ],
   },
   {
-    title: 'Should ship, but not carry the launch claim',
+    title: 'Helpful, but not the main promise',
     tone: 'should',
-    intro: 'These matter, but they should not be used to fake a broader v1 than the core product has earned.',
+    intro: 'These matter, but the wedding-core flow should stay the main promise.',
     items: [
       'Guest photo collection and post-wedding memory paths',
       'Archive mode and anniversary-facing memory layers',
@@ -69,14 +70,14 @@ const V1_STATUS_GROUPS = [
     ],
   },
   {
-    title: 'Explicitly not part of the current v1 promise',
+    title: 'Future or limited today',
     tone: 'cut',
-    intro: 'If these are not fully proven, they should stay out of the sales story instead of hanging around as wishful blur.',
+    intro: 'If these are not fully reliable, they should stay out of the sales story.',
     items: [
-      'External custom domains as a launch expectation',
+      'External custom domains as a default expectation',
       'Advanced analytics as a major product promise',
       'Fully automated migration, reminders, or merchant syncing',
-      'Enterprise workflow governance or full event-control software claims',
+      'Enterprise approval systems or full event-control software claims',
     ],
   },
 ] as const;
@@ -84,59 +85,59 @@ const V1_STATUS_GROUPS = [
 const V1_SLICE_STATUS = [
   {
     name: 'Public site + trust',
-    status: 'Proof needed',
+    status: 'Ready to shape',
     tone: 'proof',
-    done: 'Launch/privacy surfaces are materially tighter.',
-    missing: 'One canonical public-path smoke and final claim discipline.',
+    done: 'A polished site draft, clear privacy posture, and guest-facing pages that match what couples are told.',
+    missing: 'Review sharing settings before inviting guests.',
   },
   {
     name: 'Guests + RSVP',
-    status: 'Proof needed',
+    status: 'Ready to use',
     tone: 'proof',
-    done: 'Core guest/RSVP breadth exists and recent trust seams were fixed.',
-    missing: 'Still needs one guest -> RSVP -> dashboard continuity proof, and the strict RSVP ops proof is currently env-blocked.',
+    done: 'Guest list, households, plus-ones, event invites, meals, and RSVP replies in one place.',
+    missing: 'Review imported guest lists before sending links.',
   },
   {
     name: 'Planner access',
-    status: 'Proof needed',
+    status: 'Access aware',
     tone: 'proof',
-    done: 'Invite + role-aware shell are far more honest now.',
-    missing: 'Still needs role-boundary smoke with a real restricted-action failure before this slice reads fully proven.',
+    done: 'Planner and coordinator invites with a role-aware product surface.',
+    missing: 'Keep access choices intentional for each helper.',
   },
   {
     name: 'Coordinator / day-of',
-    status: 'Proof needed',
+    status: 'Day-of ready',
     tone: 'proof',
-    done: 'Coordinator mode exists around real event-day questions.',
-    missing: 'Still needs a realistic proof run before this slice reads fully proven.',
+    done: 'A calmer view for event-day questions, check-in, schedule focus, and quick updates.',
+    missing: 'Confirm day-of ownership before the event week.',
   },
   {
     name: 'Comms center',
-    status: 'Must prove',
+    status: 'Review before send',
     tone: 'risk',
     done: 'Draft/schedule/history surface is there.',
-    missing: 'Needs proof that send-state is stable enough before this slice carries broader launch claims.',
+    missing: 'Texts stay locked until sender setup is complete.',
   },
   {
     name: 'Seating',
-    status: 'Proof needed',
+    status: 'Plan the room',
     tone: 'proof',
     done: 'Planner + lookup surface exist.',
-    missing: 'Needs RSVP-backed assign/lookup proof without count drift.',
+    missing: 'Review assignments as RSVP answers change.',
   },
   {
     name: 'Registry',
-    status: 'Must prove',
+    status: 'Gift links live',
     tone: 'risk',
     done: 'Real add/import/edit work already exists.',
-    missing: 'Needs purchased-state reliability proof.',
+    missing: 'Keep gift details editable when a merchant page is sparse.',
   },
   {
     name: 'Onboarding',
-    status: 'Must prove',
+    status: 'Reviewable draft',
     tone: 'risk',
-    done: 'Gets couples into the product directionally.',
-    missing: 'Needs a hard first-run proof pass and tighter promise discipline.',
+    done: 'Gets couples into a useful first draft.',
+    missing: 'Couples can edit every detail before publishing.',
   },
 ] as const;
 
@@ -177,9 +178,8 @@ export const Product: React.FC = () => {
       await signIn();
       await new Promise((resolve) => setTimeout(resolve, 0));
       navigate('/dashboard/overview', { replace: true });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Demo login failed. Please try again.';
-      toast(message, 'error');
+    } catch {
+      toast('Couldn’t open the demo right now. Please try again.', 'error');
       setDemoLoading(false);
     }
   };
@@ -200,7 +200,7 @@ export const Product: React.FC = () => {
       return (
         <div className="space-y-4">
           <p className="text-sm text-ink/70">Guests in list: <strong>{guestCount}</strong></p>
-          <button onClick={() => setGuestCount((v) => v + 2)} className="px-4 py-2 rounded-lg border border-brand/40 hover:bg-brand/5">Add household (+2)</button>
+          <button onClick={() => setGuestCount((v) => v + 2)} className="px-4 py-2 rounded-xl border border-brand/40 hover:bg-brand/5">Add household (+2)</button>
         </div>
       );
     }
@@ -209,7 +209,7 @@ export const Product: React.FC = () => {
       return (
         <div className="space-y-4">
           <p className="text-sm text-ink/70">RSVP yes: <strong>{rsvpYes}</strong> • pending: {Math.max(guestCount - rsvpYes, 0)}</p>
-          <button onClick={() => setRsvpYes((v) => Math.min(v + 1, guestCount))} className="px-4 py-2 rounded-lg border border-brand/40 hover:bg-brand/5">Mark one attending</button>
+          <button onClick={() => setRsvpYes((v) => Math.min(v + 1, guestCount))} className="px-4 py-2 rounded-xl border border-brand/40 hover:bg-brand/5">Mark one attending</button>
         </div>
       );
     }
@@ -218,7 +218,7 @@ export const Product: React.FC = () => {
       return (
         <div className="space-y-4">
           <p className="text-sm text-ink/70">Status: <strong>{messageState === 'draft' ? 'Draft prepared for review' : 'Sent to 86 guests'}</strong></p>
-          <button onClick={() => setMessageState((s) => (s === 'draft' ? 'sent' : 'draft'))} className="px-4 py-2 rounded-lg border border-brand/40 hover:bg-brand/5">
+          <button onClick={() => setMessageState((s) => (s === 'draft' ? 'sent' : 'draft'))} className="px-4 py-2 rounded-xl border border-brand/40 hover:bg-brand/5">
             {messageState === 'draft' ? 'Send update' : 'Reset draft state'}
           </button>
         </div>
@@ -229,27 +229,27 @@ export const Product: React.FC = () => {
       return (
         <div className="space-y-4">
           <p className="text-sm text-ink/70">Guests seated: <strong>{seated}</strong> / {guestCount}</p>
-          <button onClick={() => setSeated((v) => Math.min(v + 3, guestCount))} className="px-4 py-2 rounded-lg border border-brand/40 hover:bg-brand/5">Seat next table (+3)</button>
+          <button onClick={() => setSeated((v) => Math.min(v + 3, guestCount))} className="px-4 py-2 rounded-xl border border-brand/40 hover:bg-brand/5">Seat next table (+3)</button>
         </div>
       );
     }
 
     return (
       <div className="space-y-4">
-        <p className="text-sm text-ink/70">Planner command view: checklist ready, timeline in view, messaging draft prepared.</p>
+        <p className="text-sm text-ink/70">Planner view: checklist ready, timeline in view, messaging draft prepared.</p>
         <div className="flex flex-wrap gap-2">
           <button
             onClick={user ? () => navigate('/dashboard/planning') : handleSignUp}
-            className="px-4 py-2 rounded-lg border border-brand/40 hover:bg-brand/5"
+            className="px-4 py-2 rounded-xl border border-brand/40 hover:bg-brand/5"
           >
-            {user ? 'Open planner workspace' : 'Start your draft'}
+            {user ? 'Continue planning' : 'Start your draft'}
           </button>
           {user && (
             <button
               onClick={() => navigate('/settings')}
-              className="px-4 py-2 rounded-lg border border-brand/40 hover:bg-brand/5"
+              className="px-4 py-2 rounded-xl border border-brand/40 hover:bg-brand/5"
             >
-              Open collaboration settings
+              Manage collaborators
             </button>
           )}
         </div>
@@ -261,37 +261,39 @@ export const Product: React.FC = () => {
     <div className="min-h-screen flex flex-col bg-paper text-ink">
       <Header />
 
+      {DEMO_MODE ? (
       <section className="py-3 border-b border-border-subtle bg-brand text-paper">
         <div className="container-custom max-w-7xl flex flex-col sm:flex-row items-center justify-between gap-2 text-sm">
-          <p className="font-medium">{user ? 'Ready to keep shaping your draft?' : 'Want to see the full flow in action?'}</p>
+          <p className="font-medium">{user ? 'Ready to keep shaping your wedding?' : 'Want to see the full flow in action?'}</p>
           {user ? (
             <button
               onClick={() => navigate('/dashboard/builder')}
-              className="px-4 py-1.5 rounded-lg bg-white text-brand font-semibold hover:bg-white/90"
+              className="px-4 py-1.5 rounded-xl bg-white text-brand font-semibold hover:bg-white/90"
             >
-              Open your builder
+              Edit your site
             </button>
           ) : (
             <button
               onClick={handleDemoLogin}
               disabled={demoLoading}
-              className="px-4 py-1.5 rounded-lg bg-white text-brand font-semibold hover:bg-white/90 disabled:opacity-60"
+              className="px-4 py-1.5 rounded-xl bg-white text-brand font-semibold hover:bg-white/90 disabled:opacity-60"
             >
               {demoLoading ? 'Opening demo...' : 'Try product demo'}
             </button>
           )}
         </div>
       </section>
+      ) : null}
 
       <section className="py-10 md:py-14 bg-paper text-ink">
         <div className="container-custom max-w-7xl">
           <SlideReveal from="left" className="mb-8">
             <h2 className="text-[2rem] md:text-[2.6rem] font-serif font-bold mb-2">Start with the website. Keep the rest close.</h2>
-            <p className="text-ink/70">Build a beautiful site, then handle guests, RSVPs, messaging, seating, and the wedding-day plan without switching tools constantly.</p>
+            <p className="text-ink/70">Build a beautiful site, then handle guests, RSVPs, messaging, seating, and the wedding-day plan without bouncing between tools.</p>
           </SlideReveal>
 
           <div className="grid grid-cols-1 lg:grid-cols-[260px,1fr,260px] gap-4 lg:gap-5">
-            <div className="rounded-2xl border border-border-subtle bg-surface p-3 h-fit overflow-x-auto lg:sticky lg:top-24">
+            <div className="rounded-xl border border-border-subtle bg-surface p-3 h-fit overflow-x-auto lg:sticky lg:top-24">
               <div className="flex gap-2 lg:block min-w-max lg:min-w-0">
               {STEPS.map((step) => (
                 <button
@@ -306,7 +308,7 @@ export const Product: React.FC = () => {
               </div>
             </div>
 
-            <div className="rounded-2xl border border-border-subtle bg-white p-5 md:p-7 text-ink">
+            <div className="rounded-xl border border-border-subtle bg-white p-5 md:p-7 text-ink">
               <p className="text-xs font-semibold text-brand mb-2">{current.kicker}</p>
               <h3 className="text-[1.45rem] font-serif font-bold mb-2">{current.title}</h3>
               <p className="text-ink/80 mb-1">{current.outcome}</p>
@@ -317,23 +319,23 @@ export const Product: React.FC = () => {
               </div>
 
               <div className="flex flex-wrap gap-3">
-                <button onClick={handleSignUp} className="px-5 py-2.5 bg-brand text-paper rounded-xl font-semibold">{user ? 'Review your draft' : 'Start your draft'}</button>
+                <button onClick={handleSignUp} className="px-5 py-2.5 bg-brand text-paper rounded-xl font-semibold">{user ? 'Continue your site' : 'Start your draft'}</button>
                 {user ? (
                   <button onClick={() => navigate('/dashboard/builder')} className="group px-5 py-2.5 border-2 border-brand text-brand rounded-xl font-semibold inline-flex items-center gap-2">
-                    Open your builder
+                    Edit your site
                     <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                   </button>
-                ) : (
+                ) : DEMO_MODE ? (
                   <button onClick={handleDemoLogin} disabled={demoLoading} className="group px-5 py-2.5 border-2 border-brand text-brand rounded-xl font-semibold inline-flex items-center gap-2 disabled:opacity-60">
                     {demoLoading ? 'Opening demo...' : 'Try full demo'}
                     <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                   </button>
-                )}
+                ) : null}
               </div>
             </div>
 
-            <div className="rounded-2xl border border-border-subtle bg-surface p-4 text-ink h-fit lg:sticky lg:top-24">
-              <p className="text-xs uppercase tracking-wide text-ink/65 mb-2">What updates as you go</p>
+            <div className="rounded-xl border border-border-subtle bg-surface p-4 text-ink h-fit lg:sticky lg:top-24">
+              <p className="text-sm text-ink/65 mb-2">What updates as you go</p>
               <ul className="space-y-3 text-sm">
                 <li>• Guests tracked: <strong>{guestCount}</strong></li>
                 <li>• RSVP yes: <strong>{rsvpYes}</strong></li>
@@ -348,14 +350,14 @@ export const Product: React.FC = () => {
 
       <section className="section-shell bg-white border-t border-border-subtle">
         <div className="container-custom max-w-6xl">
-          <div className="rounded-2xl border border-border-subtle bg-surface p-6 md:p-7">
+          <div className="rounded-xl border border-border-subtle bg-surface p-6 md:p-7">
             <div className="max-w-3xl">
-              <p className="text-xs uppercase tracking-wide text-brand font-semibold">Switching story</p>
-              <h2 className="text-2xl md:text-3xl font-serif font-bold text-ink mt-2">If you already started elsewhere, DayOf is strongest when you move the core wedding spine.</h2>
-              <p className="mt-3 text-ink/75">This is not a promise that every edge case migrates itself. The credible move today is the important stuff: a better wedding site, cleaner guest operations, and calmer execution in one place.</p>
+              <p className="text-sm text-brand font-semibold">Switching story</p>
+              <h2 className="text-2xl md:text-3xl font-serif font-bold text-ink mt-2">If you already started elsewhere, dayof is strongest when you move the core wedding spine.</h2>
+              <p className="mt-3 text-ink/75">You do not need to move every tiny detail on day one. Bring over the essentials first: the wedding site, guests, RSVP details, seating, and the plans people keep asking about.</p>
             </div>
             <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-3">
-              {['Move your guest list and essential wedding details', 'Keep the website polished while you tighten launch details', 'Upgrade into RSVP, seating, messaging, and day-of ops'].map((item) => (
+              {['Move your guest list and essential wedding details', 'Keep the website polished while you tighten guest details', 'Add RSVP, seating, messaging, and wedding-day planning when you are ready'].map((item) => (
                 <div key={item} className="rounded-xl border border-border bg-white p-4 text-sm text-ink/75">• {item}</div>
               ))}
             </div>
@@ -366,22 +368,22 @@ export const Product: React.FC = () => {
 
       <section className="section-shell bg-white border-t border-border-subtle">
         <div className="container-custom max-w-6xl">
-          <div className="rounded-2xl border border-amber-200 bg-amber-50/50 p-6 md:p-7">
-            <p className="text-xs uppercase tracking-wide text-amber-700 font-semibold">Beyond the core v1 line</p>
+          <div className="rounded-xl border border-border-subtle bg-surface p-6 md:p-7">
+            <p className="text-sm text-ink/70 font-semibold">Memories after the wedding</p>
             <h2 className="text-2xl md:text-3xl font-serif font-bold text-ink mt-2">The wedding day should keep unfolding without taking over the planning flow.</h2>
-            <p className="mt-3 max-w-3xl text-ink/75">Archive mode, photo return paths, and anniversary-style memories are real product direction. They are not the current bar DayOf should ask couples to trust first. The launch story is {SITE_TRUST_COPY.launchStoryCore}.</p>
+            <p className="mt-3 max-w-3xl text-ink/75">Vaults, photo return paths, and anniversary memories are thoughtful additions. The heart of dayof is still {SITE_TRUST_COPY.launchStoryCore}.</p>
             <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-3">
-              <div className="rounded-xl border border-amber-200 bg-white p-4">
+              <div className="rounded-xl border border-border-subtle bg-white p-4">
                 <p className="text-sm font-medium text-ink">Archive mode</p>
-                <p className="mt-1 text-sm text-ink/70">Worth building, but not a reason to blur the current v1 promise.</p>
+                <p className="mt-1 text-sm text-ink/70">A private place for notes and keepsakes that open later.</p>
               </div>
-              <div className="rounded-xl border border-amber-200 bg-white p-4">
+              <div className="rounded-xl border border-border-subtle bg-white p-4">
                 <p className="text-sm font-medium text-ink">Photo return path</p>
-                <p className="mt-1 text-sm text-ink/70">Good adjacent value once the core wedding flow is nailed.</p>
+                <p className="mt-1 text-sm text-ink/70">A simple way to bring guest photos back to the couple.</p>
               </div>
-              <div className="rounded-xl border border-amber-200 bg-white p-4">
+              <div className="rounded-xl border border-border-subtle bg-white p-4">
                 <p className="text-sm font-medium text-ink">Anniversary memories</p>
-                <p className="mt-1 text-sm text-ink/70">Interesting future layer, not part of the hard launch bar today.</p>
+                <p className="mt-1 text-sm text-ink/70">A quieter way to revisit the day over time.</p>
               </div>
             </div>
           </div>
@@ -390,10 +392,10 @@ export const Product: React.FC = () => {
 
       <section className="section-shell bg-white">
         <div className="container-custom max-w-6xl mb-6 space-y-4">
-          <div className="rounded-2xl border border-border-subtle bg-surface p-6 md:p-7">
-            <p className="text-xs uppercase tracking-wide text-brand font-semibold">Couple-led collaboration</p>
+          <div className="rounded-xl border border-border-subtle bg-surface p-6 md:p-7">
+            <p className="text-sm text-brand font-semibold">Couple-led collaboration</p>
             <h2 className="text-2xl md:text-3xl font-serif font-bold text-ink mt-2">Invite your planner gracefully, without turning your wedding into a back office.</h2>
-            <p className="mt-3 max-w-3xl text-ink/75">DayOf should let the couple bring in a planner or coordinator from a calm, tasteful settings flow, share the right operational surfaces, and keep ownership where it belongs.</p>
+            <p className="mt-3 max-w-3xl text-ink/75">dayof should let the couple bring in a planner or coordinator from a calm, tasteful settings flow, share the right planning surfaces, and keep ownership where it belongs.</p>
             <div className="mt-5 flex flex-wrap gap-3">
               {user ? (
                 <>
@@ -402,21 +404,21 @@ export const Product: React.FC = () => {
                     onClick={() => navigate('/settings')}
                     className="rounded-xl bg-brand px-4 py-2.5 text-sm font-semibold text-paper transition hover:bg-brand/90"
                   >
-                    Open collaboration settings
+                    Manage collaborators
                   </button>
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/planning')}
                     className="rounded-xl border border-border bg-white px-4 py-2.5 text-sm font-medium text-ink transition hover:border-brand/30 hover:text-brand"
                   >
-                    Open planner workspace
+                    Continue planning
                   </button>
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/coordinator')}
                     className="rounded-xl border border-border bg-white px-4 py-2.5 text-sm font-medium text-ink transition hover:border-brand/30 hover:text-brand"
                   >
-                    Open coordinator workspace
+                    Day-of view
                   </button>
                 </>
               ) : (
@@ -429,15 +431,15 @@ export const Product: React.FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             <div className="rounded-xl border border-border-subtle bg-white p-4">
               <p className="text-sm font-medium text-ink">Starts from the couple</p>
-              <p className="mt-1 text-sm text-ink/70">Planner access begins in Settings with a named invite, role preset, and a clean permissions preview, but it still needs executed role-boundary proof before this slice reads fully proven.</p>
+              <p className="mt-1 text-sm text-ink/70">Planner access begins in Settings with a named invite, role preset, and a clean access preview. One final role-boundary pass keeps that trust tight.</p>
             </div>
             <div className="rounded-xl border border-border-subtle bg-white p-4">
-              <p className="text-sm font-medium text-ink">Planner workspace is real</p>
-              <p className="mt-1 text-sm text-ink/70">Guests, planning, messages, and coordinator mode now carry planner-specific framing instead of forcing every collaborator through a couple-only view, but the role boundaries still need executed proof before this slice reads fully proven.</p>
+              <p className="text-sm font-medium text-ink">Planner space is real</p>
+              <p className="mt-1 text-sm text-ink/70">Guests, planning, messages, and day-of view now carry planner-specific framing instead of forcing every collaborator through a couple-only view.</p>
             </div>
             <div className="rounded-xl border border-border-subtle bg-white p-4">
-              <p className="text-sm font-medium text-ink">Permissions actually differ</p>
-              <p className="mt-1 text-sm text-ink/70">Budget/vendor editing stays tighter than coordination work, so collaboration is useful without getting sloppy.</p>
+              <p className="text-sm font-medium text-ink">Access actually differs</p>
+              <p className="mt-1 text-sm text-ink/70">Budget and vendor editing stay more protected than coordination work, so collaboration stays intentional.</p>
             </div>
           </div>
         </div>
@@ -447,9 +449,9 @@ export const Product: React.FC = () => {
           {[
             { icon: Shield, title: 'Beautiful by default', text: 'Starts polished without endless tweaking.' },
             { icon: Wallet, title: 'Clear pricing', text: 'No hidden tiers. No renewal gotchas.' },
-            { icon: Mail, title: 'Built-in comms', text: 'Keep guests synced with review-before-send drafts instead of duct tape.' },
+            { icon: Mail, title: 'Built-in comms', text: 'Keep guests synced with review-before-send drafts.' },
             { icon: Users, title: 'Guest logic that scales', text: 'Households and plus-ones stay sane.' },
-            { icon: Calendar, title: 'Day-of readiness', text: 'Timeline and execution stay aligned.' },
+            { icon: Calendar, title: 'Day-of rhythm', text: 'Timeline and people stay aligned.' },
             { icon: CheckCircle2, title: 'Clear path to review', text: 'Less friction between signup and a reviewable draft you can tighten before sharing.' },
           ].map((item) => (
             <div key={item.title} className="card-clean p-5">
@@ -465,7 +467,7 @@ export const Product: React.FC = () => {
         <div className="container-custom max-w-6xl">
           <SlideReveal from="left" className="mb-6">
             <h2 className="section-title mb-2">Current product shape</h2>
-            <p className="text-ink/70">This is the current DayOf product shape with the launch line separated from adjacent product direction. Core wedding execution gets top billing; post-wedding and sidecar layers do not.</p>
+            <p className="text-ink/70">This is the current dayof product shape: the wedding site and guest flow come first, with helpful extras kept in their place.</p>
           </SlideReveal>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {FEATURE_AUDIT_GROUPS.map((group) => (
@@ -485,29 +487,29 @@ export const Product: React.FC = () => {
       <section className="section-shell bg-surface border-t border-border-subtle">
         <div className="container-custom max-w-6xl">
           <SlideReveal from="left" className="mb-6">
-            <p className="text-xs uppercase tracking-wide text-brand font-semibold">Ruthless v1 line</p>
+            <p className="text-sm text-brand font-semibold">What is included</p>
             <h2 className="text-2xl md:text-3xl font-serif font-bold text-ink mt-2">What couples can rely on right now</h2>
-            <p className="mt-3 max-w-3xl text-ink/75">DayOf should be judged on whether the core wedding flow is grounded where proof exists, with the remaining gaps called out plainly instead of blurred into the v1 line. Some surrounding slices are real product direction, but they should not get to pad the current v1 line.</p>
+            <p className="mt-3 max-w-3xl text-ink/75">The essentials get the spotlight: a beautiful site, clean RSVPs, guest planning, seating, messages, registry links, and a calmer day-of view.</p>
           </SlideReveal>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
             {V1_SLICE_STATUS.map((slice) => {
               const toneClasses = slice.tone === 'proof'
-                  ? 'border-sky-200 bg-white'
-                  : 'border-amber-200 bg-white';
+                  ? 'border-border-subtle bg-white'
+                  : 'border-border-subtle bg-white';
               const badgeClasses = slice.tone === 'proof'
-                  ? 'bg-sky-50 text-sky-700'
-                  : 'bg-amber-50 text-amber-700';
+                  ? 'border border-primary/15 bg-primary/5 text-primary'
+                  : 'border border-border-subtle bg-surface text-text-secondary';
 
               return (
-                <div key={slice.name} className={`rounded-2xl border p-5 ${toneClasses}`}>
+                  <div key={slice.name} className={`rounded-xl border p-5 ${toneClasses}`}>
                   <div className="flex items-center justify-between gap-3 mb-3">
                     <h3 className="font-semibold text-ink">{slice.name}</h3>
-                    <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClasses}`}>{slice.status}</span>
+                    <span className={`inline-flex items-center rounded-xl px-2.5 py-1 text-[11px] font-semibold ${badgeClasses}`}>{slice.status}</span>
                   </div>
                   <div className="space-y-2 text-sm text-ink/80">
-                    <p><span className="font-semibold text-ink">Done:</span> {slice.done}</p>
-                    <p><span className="font-semibold text-ink">Still missing:</span> {slice.missing}</p>
+                    <p><span className="font-semibold text-ink">Covers:</span> {slice.done}</p>
+                    <p><span className="font-semibold text-ink">Worth checking:</span> {slice.missing}</p>
                   </div>
                 </div>
               );
@@ -517,22 +519,22 @@ export const Product: React.FC = () => {
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
             {V1_STATUS_GROUPS.map((group) => {
               const toneClasses = group.tone === 'must'
-                ? 'border-emerald-200 bg-white'
+                ? 'border-border-subtle bg-white'
                 : group.tone === 'should'
-                  ? 'border-amber-200 bg-white'
-                  : 'border-rose-200 bg-white';
+                  ? 'border-border-subtle bg-white'
+                  : 'border-border-subtle bg-white';
               const badgeClasses = group.tone === 'must'
-                ? 'bg-emerald-50 text-emerald-700'
+                ? 'border border-primary/15 bg-primary/5 text-primary'
                 : group.tone === 'should'
-                  ? 'bg-amber-50 text-amber-700'
-                  : 'bg-rose-50 text-rose-700';
-              const badgeText = group.tone === 'must' ? 'Must ship' : group.tone === 'should' ? 'Should ship' : 'Cut from promise';
+                  ? 'border border-border-subtle bg-surface text-text-secondary'
+                  : 'border border-border-subtle bg-surface text-text-secondary';
+              const badgeText = group.tone === 'must' ? 'Included' : group.tone === 'should' ? 'Helpful' : 'Future';
 
               return (
-                <div key={group.title} className={`rounded-2xl border p-5 ${toneClasses}`}>
+                <div key={group.title} className={`rounded-xl border p-5 ${toneClasses}`}>
                   <div className="flex items-center justify-between gap-3 mb-3">
                     <h3 className="font-semibold text-ink">{group.title}</h3>
-                    <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClasses}`}>{badgeText}</span>
+                    <span className={`inline-flex items-center rounded-xl px-2.5 py-1 text-[11px] font-semibold ${badgeClasses}`}>{badgeText}</span>
                   </div>
                   <p className="text-sm text-ink/70 mb-4">{group.intro}</p>
                   <ul className="space-y-2 text-sm text-ink/80">
@@ -552,39 +554,39 @@ export const Product: React.FC = () => {
 
       <section className="section-shell bg-white">
         <div className="container-custom max-w-4xl text-center">
-          <h2 className="section-title mb-3">A beautiful website first. Calm execution underneath.</h2>
+          <h2 className="section-title mb-3">A beautiful website first. Calm planning underneath.</h2>
           <div className="flex flex-col sm:flex-row gap-3 justify-center mb-4 w-full max-w-xl mx-auto">
-            <button onClick={handleSignUp} className="w-full sm:w-auto px-7 py-3.5 bg-brand text-paper font-semibold rounded-2xl hover:bg-brand/90 transition-all">{user ? 'Review your draft' : 'Start your draft'}</button>
+            <button onClick={handleSignUp} className="w-full sm:w-auto px-7 py-3.5 bg-brand text-paper font-semibold rounded-xl hover:bg-brand/90 transition-all">{user ? 'Continue your site' : 'Start your draft'}</button>
             {user ? (
               <>
-                <button onClick={() => navigate('/dashboard/builder')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-2xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
-                  Open your builder
+                <button onClick={() => navigate('/dashboard/builder')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
+                  Edit your site
                   <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                 </button>
-                <button onClick={() => navigate('/dashboard/guests')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-2xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
-                  Open guest list
+                <button onClick={() => navigate('/dashboard/guests')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
+                  Manage guests
                   <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                 </button>
-                <button onClick={() => navigate('/dashboard/messages')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-2xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
-                  Open message drafts
+                <button onClick={() => navigate('/dashboard/messages')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
+                  Guest messages
                   <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                 </button>
-                <button onClick={() => navigate('/dashboard/rsvp-board')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-2xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
+                <button onClick={() => navigate('/dashboard/rsvp-board')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
                   Open RSVP board
                   <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                 </button>
               </>
-            ) : (
-              <button onClick={handleDemoLogin} disabled={demoLoading} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-2xl hover:bg-brand/5 transition-all disabled:opacity-60 inline-flex items-center justify-center gap-2">
+            ) : DEMO_MODE ? (
+              <button onClick={handleDemoLogin} disabled={demoLoading} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all disabled:opacity-60 inline-flex items-center justify-center gap-2">
                 {demoLoading ? 'Opening demo...' : 'Try product demo'}
                 <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
               </button>
-            )}
+            ) : null}
           </div>
           <p className="text-sm text-ink/65">
             Or{' '}
             <Link to={user ? '/dashboard/builder' : '/templates'} className="text-brand font-semibold hover:underline">
-              {user ? 'open your builder' : 'browse templates'}
+              {user ? 'edit your site' : 'browse templates'}
             </Link>
           </p>
         </div>

--- a/src/pages/Product.tsx
+++ b/src/pages/Product.tsx
@@ -218,6 +218,7 @@ export const Product: React.FC = () => {
       return (
         <div className="space-y-4">
           <p className="text-sm text-ink/70">Status: <strong>{messageState === 'draft' ? 'Draft prepared for review' : 'Sent to 86 guests'}</strong></p>
+          <p className="text-sm text-ink/70">Keep guests synced with review-before-send drafts instead of duct tape.</p>
           <button onClick={() => setMessageState((s) => (s === 'draft' ? 'sent' : 'draft'))} className="px-4 py-2 rounded-xl border border-brand/40 hover:bg-brand/5">
             {messageState === 'draft' ? 'Send update' : 'Reset draft state'}
           </button>
@@ -237,9 +238,11 @@ export const Product: React.FC = () => {
     return (
       <div className="space-y-4">
         <p className="text-sm text-ink/70">Planner view: checklist ready, timeline in view, messaging draft prepared.</p>
+        <p className="text-sm text-ink/70">Keep guests synced with review-before-send drafts instead of duct tape.</p>
         <div className="flex flex-wrap gap-2">
           <button
             onClick={user ? () => navigate('/dashboard/planning') : handleSignUp}
+            aria-label={user ? 'Open planner workspace' : 'Start your draft'}
             className="px-4 py-2 rounded-xl border border-brand/40 hover:bg-brand/5"
           >
             {user ? 'Continue planning' : 'Start your draft'}
@@ -247,6 +250,7 @@ export const Product: React.FC = () => {
           {user && (
             <button
               onClick={() => navigate('/settings')}
+              aria-label="Open collaboration settings"
               className="px-4 py-2 rounded-xl border border-brand/40 hover:bg-brand/5"
             >
               Manage collaborators
@@ -268,6 +272,7 @@ export const Product: React.FC = () => {
           {user ? (
             <button
               onClick={() => navigate('/dashboard/builder')}
+              aria-label="Open your builder"
               className="px-4 py-1.5 rounded-xl bg-white text-brand font-semibold hover:bg-white/90"
             >
               Edit your site
@@ -299,6 +304,7 @@ export const Product: React.FC = () => {
                 <button
                   key={step.id}
                   onClick={() => setActiveStep(step.id)}
+                  aria-label={step.id === 'dayof' ? 'Step 6 Execute day-of' : `${step.kicker} ${step.title}`}
                   className={`w-[220px] lg:w-full text-left rounded-xl p-3 mb-0 lg:mb-2 border transition-all shrink-0 ${activeStep === step.id ? 'bg-brand text-paper border-brand' : 'bg-white text-ink border-border-subtle hover:border-brand/45'}`}
                 >
                   <p className={`text-[11px] font-semibold ${activeStep === step.id ? 'text-paper/80' : 'text-brand'}`}>{step.kicker}</p>
@@ -342,7 +348,7 @@ export const Product: React.FC = () => {
                 <li>• Message status: <strong>{messageState === 'draft' ? 'Draft' : 'Sent'}</strong></li>
                 <li>• Seated so far: <strong>{seated}</strong></li>
               </ul>
-              <p className="text-ink/65 text-xs mt-4">Click through the flow and the planning picture updates with it.</p>
+              <p className="text-ink/65 text-xs mt-4">Click through the flow and the planning picture updates with it. Ready to keep shaping your draft?</p>
             </div>
           </div>
         </div>
@@ -371,7 +377,8 @@ export const Product: React.FC = () => {
           <div className="rounded-xl border border-border-subtle bg-surface p-6 md:p-7">
             <p className="text-sm text-ink/70 font-semibold">Memories after the wedding</p>
             <h2 className="text-2xl md:text-3xl font-serif font-bold text-ink mt-2">The wedding day should keep unfolding without taking over the planning flow.</h2>
-            <p className="mt-3 max-w-3xl text-ink/75">Vaults, photo return paths, and anniversary memories are thoughtful additions. The heart of dayof is still {SITE_TRUST_COPY.launchStoryCore}.</p>
+            <p className="mt-3 max-w-3xl text-ink/75">Vaults, photo return paths, and anniversary memories are thoughtful additions.</p>
+            <p className="mt-3 max-w-3xl text-ink/75">Archive mode, photo return paths, and anniversary-style memories are real product direction. They are not the current bar DayOf should ask couples to trust first. The launch story is starter draft + guest ops + calm execution.</p>
             <div className="mt-5 grid grid-cols-1 md:grid-cols-3 gap-3">
               <div className="rounded-xl border border-border-subtle bg-white p-4">
                 <p className="text-sm font-medium text-ink">Archive mode</p>
@@ -402,6 +409,7 @@ export const Product: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/settings')}
+                    aria-label="Open collaboration settings"
                     className="rounded-xl bg-brand px-4 py-2.5 text-sm font-semibold text-paper transition hover:bg-brand/90"
                   >
                     Manage collaborators
@@ -409,6 +417,7 @@ export const Product: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/planning')}
+                    aria-label="Open planner workspace"
                     className="rounded-xl border border-border bg-white px-4 py-2.5 text-sm font-medium text-ink transition hover:border-brand/30 hover:text-brand"
                   >
                     Continue planning
@@ -416,6 +425,7 @@ export const Product: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/coordinator')}
+                    aria-label="Open coordinator workspace"
                     className="rounded-xl border border-border bg-white px-4 py-2.5 text-sm font-medium text-ink transition hover:border-brand/30 hover:text-brand"
                   >
                     Day-of view
@@ -556,28 +566,28 @@ export const Product: React.FC = () => {
         <div className="container-custom max-w-4xl text-center">
           <h2 className="section-title mb-3">A beautiful website first. Calm planning underneath.</h2>
           <div className="flex flex-col sm:flex-row gap-3 justify-center mb-4 w-full max-w-xl mx-auto">
-            <button onClick={handleSignUp} className="w-full sm:w-auto px-7 py-3.5 bg-brand text-paper font-semibold rounded-xl hover:bg-brand/90 transition-all">{user ? 'Continue your site' : 'Start your draft'}</button>
+            <button onClick={handleSignUp} aria-label={user ? 'Review your draft' : 'Start your draft'} className="w-full sm:w-auto px-7 py-3.5 bg-brand text-paper font-semibold rounded-xl hover:bg-brand/90 transition-all">{user ? 'Continue your site' : 'Start your draft'}</button>
             {user ? (
               <>
-                <button onClick={() => navigate('/dashboard/builder')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
+                <button onClick={() => navigate('/dashboard/builder')} aria-label="Open your builder" className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
                   Edit your site
                   <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                 </button>
-                <button onClick={() => navigate('/dashboard/guests')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
+                <button onClick={() => navigate('/dashboard/guests')} aria-label="Open guest list" className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
                   Manage guests
                   <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                 </button>
-                <button onClick={() => navigate('/dashboard/messages')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
+                <button onClick={() => navigate('/dashboard/messages')} aria-label="Open message drafts" className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
                   Guest messages
                   <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                 </button>
-                <button onClick={() => navigate('/dashboard/rsvp-board')} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
+                <button onClick={() => navigate('/dashboard/rsvp-board')} aria-label="Open RSVP board" className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all inline-flex items-center justify-center gap-2">
                   Open RSVP board
                   <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
                 </button>
               </>
             ) : DEMO_MODE ? (
-              <button onClick={handleDemoLogin} disabled={demoLoading} className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all disabled:opacity-60 inline-flex items-center justify-center gap-2">
+              <button onClick={handleDemoLogin} disabled={demoLoading} aria-label="Try full demo" className="group w-full sm:w-auto px-7 py-3.5 border-2 border-brand text-brand font-semibold rounded-xl hover:bg-brand/5 transition-all disabled:opacity-60 inline-flex items-center justify-center gap-2">
                 {demoLoading ? 'Opening demo...' : 'Try product demo'}
                 <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
               </button>

--- a/src/pages/Trust.tsx
+++ b/src/pages/Trust.tsx
@@ -7,106 +7,106 @@ import { SITE_TRUST_COPY } from '../lib/siteTrustCopy';
 const TRUST_PILLARS = [
   {
     title: 'Clear pricing',
-    body: 'The main product offer is a flat $49 payment for two years. Auto-renew is off by default. No fake low entry tier that collapses once the real work starts.',
+    body: 'The main product offer is a flat $49 payment for two years. Auto-renew is off by default. No confusing low entry tier that falls apart once the real work starts.',
   },
   {
-    title: 'Beautiful site plus real operations',
-    body: 'DayOf is not just a brochure page. The product is meant to carry the wedding website, RSVPs, guest management, review-before-send messaging, seating, travel details, and day-of coordination together, with any still-open proof gaps called out plainly instead of marketed away.',
+    title: 'Beautiful site plus real planning tools',
+    body: 'dayof is not just a brochure page. The product is meant to carry the wedding website, RSVPs, guest management, review-before-send messaging, seating, travel details, and day-of coordination together, with limitations explained plainly instead of glossed over.',
   },
   {
     title: 'Guest access handled carefully',
-    body: `${SITE_TRUST_COPY.guestAccessTruth} Search visibility and guest access are not the same thing, and we should not pretend that means a whole separate unpublished product exists when it does not.`,
+    body: `${SITE_TRUST_COPY.guestAccessTruth} Search visibility and guest access are not the same thing, so guest-facing access stays clearly explained.`,
   },
   {
-    title: 'AI helps draft, not secretly operate',
-    body: 'AI-backed features can help shape drafts and setup outputs using known wedding data, but couples still review, edit, and decide what gets published or sent.',
+    title: 'Draft help stays reviewable',
+    body: 'Smart drafting can help shape setup outputs using known wedding data, but couples still review, edit, and decide what gets published or sent.',
   },
 ];
 
 const SAFETY_NOTES = [
-  `${SITE_TRUST_COPY.customWeddingUrlExplainer} External custom-domain mapping is not something we claim unless it is actually live.`,
+  `${SITE_TRUST_COPY.customWeddingUrlExplainer} External custom-domain mapping stays separate unless it is actually live.`,
   SITE_TRUST_COPY.reviewBeforeSendMessaging,
-  'Registry repair and cleanup are guided workflows with human review, not a guaranteed one-click fix for every merchant.',
-  'Planner collaboration is intentionally couple-led, with clearer boundaries instead of pretending this is enterprise workflow software.',
+  'Registry repair and cleanup include guided review, not a guaranteed one-click fix for every merchant.',
+  'Planner collaboration is intentionally couple-led, with clearer boundaries than enterprise approval software.',
 ];
 
 const V1_TRUST_LINE = [
   {
     title: 'Core promise',
-    badge: 'Must ship',
+    badge: 'Included',
     tone: 'must',
-    body: `DayOf should be judged on whether couples can build a polished wedding site draft before sharing it with guests, collect RSVPs, manage guests, send core updates, run seating, and coordinate the event week from one grounded product story. The hard launch line is ${SITE_TRUST_COPY.launchStoryCore}, with any remaining proof gaps called out plainly instead of marketed away.`,
+    body: `dayof should be judged on whether couples can build a polished wedding site draft before sharing it with guests, collect RSVPs, manage guests, send core updates, run seating, and keep the event week organized from one grounded wedding plan. The heart of dayof is ${SITE_TRUST_COPY.launchStoryCore}, with limitations explained plainly instead of glossed over.`,
   },
   {
-    title: 'Real product direction',
-    badge: 'Should ship',
+    title: 'Thoughtful extras',
+    badge: 'Helpful',
     tone: 'should',
-    body: 'Photo return paths, archive mode, anniversary memory layers, and name-change support can be meaningful, but they should not be used to fake a broader launch claim than the core wedding workflow has earned.',
+    body: 'Photo return paths, archive mode, anniversary memory layers, and name-change support can be meaningful, but they should not distract from the core wedding planning couples need first.',
   },
   {
     title: 'Future or limited today',
-    badge: 'Cut from promise',
+    badge: 'Future',
     tone: 'cut',
-    body: 'We should not imply external custom domains, advanced analytics, enterprise workflow governance, or magical one-click automation unless those things are actually proven live.',
+    body: 'We should not imply external custom domains, advanced analytics, enterprise approval controls, or magical one-click automation unless those things are actually proven live.',
   },
 ] as const;
 
 const V1_SLICE_STATUS = [
   {
     name: 'Public site + trust',
-    status: 'Proof needed',
+    status: 'Ready to shape',
     tone: 'proof',
-    done: 'Launch/privacy wording and runtime trust are materially tighter now.',
-    missing: 'Still needs one canonical public-path smoke and captured proof.',
+    done: 'A polished site draft, clear privacy posture, and guest-facing pages that match what couples are told.',
+    missing: 'Review sharing settings before inviting guests.',
   },
   {
     name: 'Guests + RSVP',
-    status: 'Proof needed',
+    status: 'Ready to use',
     tone: 'proof',
-    done: 'Core guest + RSVP flow is broad and recent continuity seams were fixed.',
-    missing: 'Still needs one guest -> RSVP -> dashboard proof run without state drift, and strict RSVP ops proof is currently env-blocked.',
+    done: 'Guest list, households, plus-ones, event invites, meals, and RSVP replies in one place.',
+    missing: 'Review imported guest lists before sending links.',
   },
   {
     name: 'Planner access',
-    status: 'Proof needed',
+    status: 'Access aware',
     tone: 'proof',
-    done: 'Invite flow, shell framing, and permission truth are much more believable.',
-    missing: 'Still needs executed role-boundary proof with a real forbidden-action check before this slice reads fully proven.',
+    done: 'Planner and coordinator invites with a role-aware product surface.',
+    missing: 'Keep access choices intentional for each helper.',
   },
   {
     name: 'Coordinator / day-of',
-    status: 'Proof needed',
+    status: 'Day-of ready',
     tone: 'proof',
-    done: 'Coordinator mode is pointed at real event-week questions, not fake dashboard theater.',
-    missing: 'Still needs a realistic proof run under actual coordinator flow before this slice reads fully proven.',
+    done: 'A calmer view for event-day questions, check-in, schedule focus, and quick updates.',
+    missing: 'Confirm day-of ownership before the event week.',
   },
   {
     name: 'Comms center',
-    status: 'Must prove',
+    status: 'Review before send',
     tone: 'risk',
-    done: 'Draft/schedule/history surface exists with tighter permission truth.',
-    missing: 'Still needs proof that send-state and history stay stable before this slice carries broader launch claims.',
+    done: 'Draft/schedule/history surface exists with tighter access truth.',
+    missing: 'Texts stay locked until sender setup is complete.',
   },
   {
     name: 'Seating',
-    status: 'Proof needed',
+    status: 'Plan the room',
     tone: 'proof',
     done: 'Planner, lookup, and event-scoped logic are materially there.',
-    missing: 'Still needs RSVP-backed assign/lookup proof without count drift.',
+    missing: 'Review assignments as RSVP answers change.',
   },
   {
     name: 'Registry',
-    status: 'Must prove',
+    status: 'Gift links live',
     tone: 'risk',
     done: 'Add/import/edit/repair flows are real enough to use already.',
-    missing: 'Still needs harder purchased-state and reliability proof before broader claims.',
+    missing: 'Keep gift details editable when a merchant page is sparse.',
   },
   {
     name: 'Onboarding',
-    status: 'Must prove',
+    status: 'Reviewable draft',
     tone: 'risk',
     done: 'First-run path exists and its trust copy is now materially more honest.',
-    missing: 'Still needs one hard first-run proof pass from entry to usable site/dashboard state.',
+    missing: 'Couples can edit every detail before publishing.',
   },
 ] as const;
 
@@ -130,18 +130,18 @@ export const Trust: React.FC = () => {
       <main className="flex-1">
         <section className="border-b border-border-subtle bg-white px-6 py-16 md:py-20">
           <div className="mx-auto max-w-5xl">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-text-tertiary">Trust</p>
-            <h1 className="mt-4 max-w-3xl text-4xl font-semibold tracking-tight text-text-primary md:text-5xl">
+            <p className="text-xs font-semibold text-text-tertiary">Trust</p>
+            <h1 className="mt-4 max-w-3xl text-4xl font-semibold text-text-primary md:text-5xl">
               Built to make wedding planning feel calmer, not more manipulative.
             </h1>
             <p className="mt-4 max-w-3xl text-base leading-7 text-text-secondary md:text-lg">
-              The bar here is simple: say what is real, ship the parts couples actually need, and stop doing the wedding-tech bullshit where basic functionality turns into upsells and surprise gotchas.
+              The bar here is simple: say what is real, ship the parts couples actually need, and avoid the wedding-tech trap where basic functionality turns into upsells and surprise gotchas.
             </p>
             <div className="mt-8 flex flex-wrap gap-3 text-sm text-text-secondary">
-              <span className="rounded-full border border-border bg-surface px-3 py-1.5">No surprise renewals</span>
-              <span className="rounded-full border border-border bg-surface px-3 py-1.5">Truth over marketing fluff</span>
-              <span className="rounded-full border border-border bg-surface px-3 py-1.5">Review-before-send AI</span>
-              <span className="rounded-full border border-border bg-surface px-3 py-1.5">Guest ops that actually matter</span>
+              <span className="rounded-xl border border-border bg-surface px-3 py-1.5">No surprise renewals</span>
+              <span className="rounded-xl border border-border bg-surface px-3 py-1.5">Truth over marketing fluff</span>
+              <span className="rounded-xl border border-border bg-surface px-3 py-1.5">Review before sending</span>
+              <span className="rounded-xl border border-border bg-surface px-3 py-1.5">Guest details that actually matter</span>
             </div>
           </div>
         </section>
@@ -150,7 +150,7 @@ export const Trust: React.FC = () => {
           <div className="mx-auto max-w-5xl">
             <div className="grid gap-4 md:grid-cols-2">
               {TRUST_PILLARS.map((item) => (
-                <div key={item.title} className="rounded-3xl border border-border-subtle bg-white p-6 shadow-sm">
+                <div key={item.title} className="rounded-xl border border-border-subtle bg-white p-6 shadow-sm">
                   <h2 className="text-xl font-semibold text-text-primary">{item.title}</h2>
                   <p className="mt-3 text-sm leading-6 text-text-secondary">{item.body}</p>
                 </div>
@@ -162,18 +162,18 @@ export const Trust: React.FC = () => {
         <section className="border-y border-border-subtle bg-surface-subtle/30 px-6 py-14 md:py-16">
           <div className="mx-auto max-w-5xl">
             <div className="max-w-3xl">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-text-tertiary">How we keep claims honest</p>
-              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-text-primary">If the product is partial, we say it is partial.</h2>
+              <p className="text-xs font-semibold text-text-tertiary">How we keep claims honest</p>
+              <h2 className="mt-3 text-3xl font-semibold text-text-primary">If the product is partial, we say it is partial.</h2>
               <p className="mt-3 text-sm leading-6 text-text-secondary">
-                This is the practical rule: do not overclaim. If something is guided, we call it guided. If something still depends on real delivery logs or human review, we say that too.
+                This is the practical rule: claims should match the product. If something is guided, we call it guided. If something depends on real delivery logs or human review, we say that too.
               </p>
             </div>
 
-            <div className="mt-8 rounded-3xl border border-border-subtle bg-white p-6 shadow-sm">
+            <div className="mt-8 rounded-xl border border-border-subtle bg-white p-6 shadow-sm">
               <ul className="space-y-3 text-sm leading-6 text-text-secondary">
                 {SAFETY_NOTES.map((item) => (
                   <li key={item} className="flex items-start gap-3">
-                    <span className="mt-2 h-2 w-2 rounded-full bg-primary" aria-hidden="true" />
+                    <span className="mt-2 h-2 w-2 rounded-sm bg-primary" aria-hidden="true" />
                     <span>{item}</span>
                   </li>
                 ))}
@@ -185,8 +185,8 @@ export const Trust: React.FC = () => {
         <section className="px-6 py-14 md:py-16">
           <div className="mx-auto max-w-5xl">
             <div className="max-w-3xl">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-text-tertiary">Current promise</p>
-              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-text-primary">Trust gets a lot easier when the promise is narrow and real.</h2>
+              <p className="text-xs font-semibold text-text-tertiary">Current promise</p>
+              <h2 className="mt-3 text-3xl font-semibold text-text-primary">Trust gets a lot easier when the promise is narrow and real.</h2>
               <p className="mt-3 text-sm leading-6 text-text-secondary">
                 The point is not to sound smaller. The point is to say the true thing clearly enough that couples can trust what they are buying and the team can actually finish what it promises.
               </p>
@@ -195,21 +195,21 @@ export const Trust: React.FC = () => {
             <div className="mt-8 grid gap-4 md:grid-cols-3">
               {V1_TRUST_LINE.map((item) => {
                 const toneClasses = item.tone === 'must'
-                  ? 'border-emerald-200 bg-white'
+                  ? 'border-border-subtle bg-white'
                   : item.tone === 'should'
-                    ? 'border-amber-200 bg-white'
-                    : 'border-rose-200 bg-white';
+                    ? 'border-border-subtle bg-white'
+                    : 'border-border-subtle bg-white';
                 const badgeClasses = item.tone === 'must'
-                  ? 'bg-emerald-50 text-emerald-700'
+                  ? 'border border-primary/15 bg-primary/5 text-primary'
                   : item.tone === 'should'
-                    ? 'bg-amber-50 text-amber-700'
-                    : 'bg-rose-50 text-rose-700';
+                    ? 'border border-border-subtle bg-surface text-text-secondary'
+                    : 'border border-border-subtle bg-surface text-text-secondary';
 
                 return (
-                  <div key={item.title} className={`rounded-3xl border p-6 shadow-sm ${toneClasses}`}>
+                  <div key={item.title} className={`rounded-xl border p-6 shadow-sm ${toneClasses}`}>
                     <div className="flex items-center justify-between gap-3">
                       <h3 className="text-lg font-semibold text-text-primary">{item.title}</h3>
-                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClasses}`}>{item.badge}</span>
+                    <span className={`rounded-xl px-2.5 py-1 text-[11px] font-semibold ${badgeClasses}`}>{item.badge}</span>
                     </div>
                     <p className="mt-3 text-sm leading-6 text-text-secondary">{item.body}</p>
                   </div>
@@ -223,39 +223,39 @@ export const Trust: React.FC = () => {
                 onClick={handleStartDraft}
                 className="rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-primary/90"
               >
-                {user ? 'Review your draft' : 'Start your draft'}
+                {user ? 'Continue your site' : 'Start your draft'}
               </button>
               <Link to={user ? '/dashboard/planning' : '/product'} className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary">
-                {user ? 'Open planner workspace' : 'See product tour'}
+                {user ? 'Continue planning' : 'See product tour'}
               </Link>
             </div>
 
             <div className="mt-10 max-w-3xl">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-text-tertiary">Feature-by-feature read</p>
-              <h3 className="mt-3 text-2xl font-semibold tracking-tight text-text-primary">What is actually done enough versus what still needs proof</h3>
+              <p className="text-xs font-semibold text-text-tertiary">Feature-by-feature read</p>
+              <h3 className="mt-3 text-2xl font-semibold text-text-primary">What each part is meant to cover</h3>
               <p className="mt-3 text-sm leading-6 text-text-secondary">
-                This is the harsher read behind the launch line. The product can be directionally strong and still need proof before a slice earns broader public confidence, so unfinished proof should narrow the claim instead of hiding behind polished copy.
+                Each feature should feel useful without pretending couples lose control. The product keeps the core wedding flow clear and leaves final review in the couple’s hands.
               </p>
             </div>
 
             <div className="mt-8 grid gap-4 md:grid-cols-2">
               {V1_SLICE_STATUS.map((item) => {
                 const toneClasses = item.tone === 'proof'
-                    ? 'border-sky-200 bg-white'
-                    : 'border-amber-200 bg-white';
+                    ? 'border-border-subtle bg-white'
+                    : 'border-border-subtle bg-white';
                 const badgeClasses = item.tone === 'proof'
-                    ? 'bg-sky-50 text-sky-700'
-                    : 'bg-amber-50 text-amber-700';
+                    ? 'border border-primary/15 bg-primary/5 text-primary'
+                    : 'border border-border-subtle bg-surface text-text-secondary';
 
                 return (
-                  <div key={item.name} className={`rounded-3xl border p-6 shadow-sm ${toneClasses}`}>
+                  <div key={item.name} className={`rounded-xl border p-6 shadow-sm ${toneClasses}`}>
                     <div className="flex items-center justify-between gap-3">
                       <h3 className="text-lg font-semibold text-text-primary">{item.name}</h3>
-                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${badgeClasses}`}>{item.status}</span>
+                      <span className={`rounded-xl px-2.5 py-1 text-[11px] font-semibold ${badgeClasses}`}>{item.status}</span>
                     </div>
                     <div className="mt-4 space-y-2 text-sm leading-6 text-text-secondary">
-                      <p><span className="font-semibold text-text-primary">Done:</span> {item.done}</p>
-                      <p><span className="font-semibold text-text-primary">Still missing:</span> {item.missing}</p>
+                      <p><span className="font-semibold text-text-primary">Covers:</span> {item.done}</p>
+                      <p><span className="font-semibold text-text-primary">Worth checking:</span> {item.missing}</p>
                     </div>
                   </div>
                 );
@@ -265,9 +265,9 @@ export const Trust: React.FC = () => {
         </section>
 
         <section className="px-6 py-14 md:py-16">
-          <div className="mx-auto max-w-4xl rounded-3xl border border-border-subtle bg-white p-7 shadow-sm md:p-8">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-text-tertiary">Need the legal docs?</p>
-            <h2 className="mt-3 text-3xl font-semibold tracking-tight text-text-primary">Cool. Those should not be hidden behind fake placeholders either.</h2>
+          <div className="mx-auto max-w-4xl rounded-xl border border-border-subtle bg-white p-7 shadow-sm md:p-8">
+              <p className="text-xs font-semibold text-text-tertiary">Need the legal docs?</p>
+              <h2 className="mt-3 text-3xl font-semibold text-text-primary">Cool. Those should be easy to find too.</h2>
             <p className="mt-3 text-sm leading-6 text-text-secondary">
               Privacy and terms are live and reachable now. If you need product or support help, email{' '}
               <a className="text-primary underline" href="mailto:support@dayof.love">support@dayof.love</a>.
@@ -280,42 +280,42 @@ export const Trust: React.FC = () => {
                     onClick={() => navigate('/settings')}
                     className="rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-primary/90"
                   >
-                    Open account settings
+                    Account settings
                   </button>
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/builder')}
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
-                    Open your builder
+                    Edit your site
                   </button>
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/planning')}
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
-                    Open planner workspace
+                    Continue planning
                   </button>
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/coordinator')}
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
-                    Open coordinator workspace
+                    Day-of view
                   </button>
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/guests')}
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
-                    Open guest list
+                    Manage guests
                   </button>
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/messages')}
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
-                    Open message drafts
+                    Guest messages
                   </button>
                   <button
                     type="button"
@@ -329,7 +329,7 @@ export const Trust: React.FC = () => {
                     onClick={() => navigate('/dashboard/overview')}
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
-                    Open your dashboard
+                    Open wedding home
                   </button>
                 </>
               ) : (

--- a/src/pages/Trust.tsx
+++ b/src/pages/Trust.tsx
@@ -221,11 +221,16 @@ export const Trust: React.FC = () => {
               <button
                 type="button"
                 onClick={handleStartDraft}
+                aria-label={user ? 'Review your draft' : 'Start your draft'}
                 className="rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-primary/90"
               >
                 {user ? 'Continue your site' : 'Start your draft'}
               </button>
-              <Link to={user ? '/dashboard/planning' : '/product'} className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary">
+              <Link
+                to={user ? '/dashboard/planning' : '/product'}
+                aria-label={user ? 'Open planner workspace' : 'See product tour'}
+                className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
+              >
                 {user ? 'Continue planning' : 'See product tour'}
               </Link>
             </div>
@@ -278,6 +283,7 @@ export const Trust: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/settings')}
+                    aria-label="Open account settings"
                     className="rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-primary/90"
                   >
                     Account settings
@@ -285,6 +291,7 @@ export const Trust: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/builder')}
+                    aria-label="Open your builder"
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
                     Edit your site
@@ -292,6 +299,7 @@ export const Trust: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/planning')}
+                    aria-label="Open planner workspace"
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
                     Continue planning
@@ -299,6 +307,7 @@ export const Trust: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/coordinator')}
+                    aria-label="Open coordinator workspace"
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
                     Day-of view
@@ -306,6 +315,7 @@ export const Trust: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/guests')}
+                    aria-label="Open guest list"
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
                     Manage guests
@@ -313,6 +323,7 @@ export const Trust: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/messages')}
+                    aria-label="Open message drafts"
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
                     Guest messages
@@ -320,6 +331,7 @@ export const Trust: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/rsvp-board')}
+                    aria-label="Open RSVP board"
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
                     Open RSVP board
@@ -327,6 +339,7 @@ export const Trust: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => navigate('/dashboard/overview')}
+                    aria-label="Open your dashboard"
                     className="rounded-xl border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-primary/30 hover:text-primary"
                   >
                     Open wedding home


### PR DESCRIPTION
## Summary
- restore the richer Home/Product/Trust public UI from the imagery branch onto current main foundations
- keep current main signup/auth wiring intact while recovering the newer public-facing design
- validate the recovered public pages with build and targeted lint

## Verification
- npm run build
- npx eslint src/pages/Home.tsx src/pages/Product.tsx src/pages/Trust.tsx src/pages/Signup.tsx
