### PR TITLE
Repair non-registry proof lanes and restore identity exports

### DIFF
--- a/scripts/v1-proof-budget-vendor-ledger.mjs
+++ b/scripts/v1-proof-budget-vendor-ledger.mjs
@@ -3,8 +3,11 @@
 import { execSync } from 'node:child_process';
 import { resolvePreviewRuntime, stopPreviewRuntime } from './proofPreviewRuntime.mjs';
 
-const PREVIEW_URL = 'http://127.0.0.1:4176';
+const PREVIEW_PORT = 4180;
+const PREVIEW_URL = `http://127.0.0.1:${PREVIEW_PORT}`;
 const requestedBaseUrl = process.env.PLAYWRIGHT_BASE_URL || PREVIEW_URL;
+const browserSpec = 'tests/e2e/mobile-core-smoke.spec.ts';
+const browserGrep = 'authenticated dashboard core routes render on mobile without native dialog regressions';
 
 function runStep(step) {
   const startedAt = new Date().toISOString();
@@ -14,7 +17,6 @@ function runStep(step) {
       encoding: 'utf8',
       shell: '/bin/zsh',
       env: process.env,
-      timeout: step.timeoutMs ?? 180_000,
       maxBuffer: 20 * 1024 * 1024,
     });
 
@@ -48,29 +50,27 @@ function runStep(step) {
 
 const results = [
   runStep({
-    id: 'photo-memory-tests',
-    label: 'Photo memory flow unit and boundary tests',
-    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/components/dashboard/PhotoBucketCards.test.tsx src/pages/dashboard/guestPhotoDateTime.test.ts src/pages/dashboard/guestPhotoEventDate.test.ts src/pages/dashboard/guestPhotoUploadTime.test.ts src/lib/photoUploadSafety.test.ts',
-    timeoutMs: 240_000,
+    id: 'budget-vendor-logic-tests',
+    label: 'Budget and vendor date + action boundary tests',
+    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/pages/dashboard/planning/vendorDate.test.ts src/pages/dashboard/planning/usePlanningDashboardActions.test.tsx src/lib/plannerAccess.test.ts',
   }),
   runStep({
     id: 'build',
     label: 'Build integrity check',
     command: 'npm run build',
-    timeoutMs: 900_000,
   }),
 ];
 
 let previewProcess = null;
 let previewOutput = { stdout: '', stderr: '' };
 let activeBaseUrl = requestedBaseUrl;
+
 try {
   if (requestedBaseUrl === PREVIEW_URL) {
     const previewRuntime = await resolvePreviewRuntime({
-      preferredPort: 4176,
+      preferredPort: PREVIEW_PORT,
       requestedBaseUrl,
       cwd: process.cwd(),
-      startupTimeoutMs: 120_000,
     });
     previewProcess = previewRuntime.previewProcess;
     previewOutput = previewRuntime.previewOutput;
@@ -78,35 +78,20 @@ try {
   }
 
   results.push(runStep({
-    id: 'photo-memory-browser-proof',
-    label: 'Photo memory flow browser proof',
-    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 tests/e2e/mobile-core-smoke.spec.ts`,
-    timeoutMs: 900_000,
+    id: 'budget-vendor-browser-proof',
+    label: 'Budget and vendor mobile dashboard proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec} -g "${browserGrep}"`,
   }));
-
-  if (previewOutput.stdout.trim()) {
-    results.push({
-      id: 'preview-server-log',
-      label: 'Preview server log',
-      command: 'npm run preview -- --host 127.0.0.1 --port 4176',
-      required: false,
-      ok: true,
-      startedAt: new Date().toISOString(),
-      finishedAt: new Date().toISOString(),
-      stdout: previewOutput.stdout.trim(),
-      stderr: previewOutput.stderr.trim() || undefined,
-    });
-  }
 } catch (error) {
   results.push({
-    id: 'photo-memory-browser-proof',
-    label: 'Photo memory flow browser proof',
-    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 tests/e2e/mobile-core-smoke.spec.ts`,
+    id: 'budget-vendor-browser-proof',
+    label: 'Budget and vendor mobile dashboard proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec} -g "${browserGrep}"`,
     required: true,
     ok: false,
     startedAt: new Date().toISOString(),
     finishedAt: new Date().toISOString(),
-    stderr: [previewOutput.stderr.trim(), error instanceof Error ? error.message : 'Photo memory flow preview server failed to start.'].filter(Boolean).join('\n'),
+    stderr: [previewOutput.stderr.trim(), error instanceof Error ? error.message : 'Budget/vendor preview server failed to start.'].filter(Boolean).join('\n'),
   });
 } finally {
   await stopPreviewRuntime(previewProcess);
@@ -115,7 +100,7 @@ try {
 const failedRequired = results.filter((result) => result.required && !result.ok);
 const output = {
   ok: failedRequired.length === 0,
-  slice: 'photo-memory-flow',
+  slice: 'budget-vendor-ledger',
   generatedAt: new Date().toISOString(),
   summary: {
     total: results.length,
@@ -123,16 +108,16 @@ const output = {
     failed: results.filter((result) => !result.ok).length,
   },
   contractSummary: failedRequired.length === 0
-    ? 'Photo memory flow proof is green: this feature bundle validates memory/recap upload-and-readback continuity as shipped lane evidence while still deferring the final launch call to the proof-board flow.'
-    : 'Photo memory flow proof is not green yet: required unit, build, or browser evidence is still failing.',
+    ? 'Budget and vendor ledger proof is green: the current owner/planner ledger boundaries and dashboard surface are intact.'
+    : 'Budget and vendor ledger proof is not green yet: required planner logic, build, or dashboard browser evidence is still failing.',
   automatedCoverage: [
-    'Photo bucket card rendering plus guest-photo date/time normalization helpers',
-    'Guest-safe photo upload fallback messaging for the public route',
-    'Mobile guest photo-upload route continuity without raw-token leakage',
-    'Mobile dashboard visibility for the no-app memory flow, QR guest hub, and print-card controls',
+    'Vendor date normalization and planning-action permission boundaries',
+    'Planner/coordinator role boundary truth for budget and vendor access',
+    'Mobile dashboard presence of the budget and vendor ledger surface, payment review, and export control',
+    'Build integrity after budget/vendor assertions',
   ],
   stillManualProofNeeded: [
-    'Keep the live upload-to-recap and owner export lane green after future photo-surface deploys.',
+    'Keep live add/edit/delete and export cleanup proof fresh on the shipped runtime after future planning-surface deploys.',
   ],
   results,
 };

--- a/scripts/v1-proof-dayof-web-mode.mjs
+++ b/scripts/v1-proof-dayof-web-mode.mjs
@@ -3,8 +3,11 @@
 import { execSync } from 'node:child_process';
 import { resolvePreviewRuntime, stopPreviewRuntime } from './proofPreviewRuntime.mjs';
 
-const PREVIEW_URL = 'http://127.0.0.1:4176';
+const PREVIEW_PORT = 4174;
+const PREVIEW_URL = `http://127.0.0.1:${PREVIEW_PORT}`;
 const requestedBaseUrl = process.env.PLAYWRIGHT_BASE_URL || PREVIEW_URL;
+const browserSpec = 'tests/e2e/mobile-core-smoke.spec.ts';
+const browserGrep = 'guest-facing mobile routes stay reachable and token-free where intended';
 
 function runStep(step) {
   const startedAt = new Date().toISOString();
@@ -14,7 +17,6 @@ function runStep(step) {
       encoding: 'utf8',
       shell: '/bin/zsh',
       env: process.env,
-      timeout: step.timeoutMs ?? 180_000,
       maxBuffer: 20 * 1024 * 1024,
     });
 
@@ -48,29 +50,27 @@ function runStep(step) {
 
 const results = [
   runStep({
-    id: 'photo-memory-tests',
-    label: 'Photo memory flow unit and boundary tests',
-    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/components/dashboard/PhotoBucketCards.test.tsx src/pages/dashboard/guestPhotoDateTime.test.ts src/pages/dashboard/guestPhotoEventDate.test.ts src/pages/dashboard/guestPhotoUploadTime.test.ts src/lib/photoUploadSafety.test.ts',
-    timeoutMs: 240_000,
+    id: 'dayof-web-mode-tests',
+    label: 'Public site and guest-hub route continuity tests',
+    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/pages/SiteView.test.ts src/lib/publicSiteProject.test.ts src/lib/publicSiteSlug.test.ts',
   }),
   runStep({
     id: 'build',
     label: 'Build integrity check',
     command: 'npm run build',
-    timeoutMs: 900_000,
   }),
 ];
 
 let previewProcess = null;
 let previewOutput = { stdout: '', stderr: '' };
 let activeBaseUrl = requestedBaseUrl;
+
 try {
   if (requestedBaseUrl === PREVIEW_URL) {
     const previewRuntime = await resolvePreviewRuntime({
-      preferredPort: 4176,
+      preferredPort: PREVIEW_PORT,
       requestedBaseUrl,
       cwd: process.cwd(),
-      startupTimeoutMs: 120_000,
     });
     previewProcess = previewRuntime.previewProcess;
     previewOutput = previewRuntime.previewOutput;
@@ -78,35 +78,20 @@ try {
   }
 
   results.push(runStep({
-    id: 'photo-memory-browser-proof',
-    label: 'Photo memory flow browser proof',
-    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 tests/e2e/mobile-core-smoke.spec.ts`,
-    timeoutMs: 900_000,
+    id: 'dayof-web-mode-browser-proof',
+    label: 'Guest-facing mobile wedding-hub browser proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec} -g "${browserGrep}"`,
   }));
-
-  if (previewOutput.stdout.trim()) {
-    results.push({
-      id: 'preview-server-log',
-      label: 'Preview server log',
-      command: 'npm run preview -- --host 127.0.0.1 --port 4176',
-      required: false,
-      ok: true,
-      startedAt: new Date().toISOString(),
-      finishedAt: new Date().toISOString(),
-      stdout: previewOutput.stdout.trim(),
-      stderr: previewOutput.stderr.trim() || undefined,
-    });
-  }
 } catch (error) {
   results.push({
-    id: 'photo-memory-browser-proof',
-    label: 'Photo memory flow browser proof',
-    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 tests/e2e/mobile-core-smoke.spec.ts`,
+    id: 'dayof-web-mode-browser-proof',
+    label: 'Guest-facing mobile wedding-hub browser proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec} -g "${browserGrep}"`,
     required: true,
     ok: false,
     startedAt: new Date().toISOString(),
     finishedAt: new Date().toISOString(),
-    stderr: [previewOutput.stderr.trim(), error instanceof Error ? error.message : 'Photo memory flow preview server failed to start.'].filter(Boolean).join('\n'),
+    stderr: [previewOutput.stderr.trim(), error instanceof Error ? error.message : 'Day-of web mode preview server failed to start.'].filter(Boolean).join('\n'),
   });
 } finally {
   await stopPreviewRuntime(previewProcess);
@@ -115,7 +100,7 @@ try {
 const failedRequired = results.filter((result) => result.required && !result.ok);
 const output = {
   ok: failedRequired.length === 0,
-  slice: 'photo-memory-flow',
+  slice: 'dayof-web-mode',
   generatedAt: new Date().toISOString(),
   summary: {
     total: results.length,
@@ -123,16 +108,15 @@ const output = {
     failed: results.filter((result) => !result.ok).length,
   },
   contractSummary: failedRequired.length === 0
-    ? 'Photo memory flow proof is green: this feature bundle validates memory/recap upload-and-readback continuity as shipped lane evidence while still deferring the final launch call to the proof-board flow.'
-    : 'Photo memory flow proof is not green yet: required unit, build, or browser evidence is still failing.',
+    ? 'Day-of web mode proof is green: the public guest-hub path stays reachable on mobile without app-only assumptions.'
+    : 'Day-of web mode proof is not green yet: required route, build, or guest-hub browser evidence is still failing.',
   automatedCoverage: [
-    'Photo bucket card rendering plus guest-photo date/time normalization helpers',
-    'Guest-safe photo upload fallback messaging for the public route',
-    'Mobile guest photo-upload route continuity without raw-token leakage',
-    'Mobile dashboard visibility for the no-app memory flow, QR guest hub, and print-card controls',
+    'Public site + guest-hub route continuity helpers',
+    'Guest-facing mobile route continuity through RSVP, travel, photo upload, recap, guestbook, and vault paths',
+    'Build integrity after day-of web mode assertions',
   ],
   stillManualProofNeeded: [
-    'Keep the live upload-to-recap and owner export lane green after future photo-surface deploys.',
+    'Rerun the shipped guest-hub mobile path after future guest-facing route or wording deploys.',
   ],
   results,
 };

--- a/scripts/v1-proof-guest-hub-qr.mjs
+++ b/scripts/v1-proof-guest-hub-qr.mjs
@@ -3,8 +3,12 @@
 import { execSync } from 'node:child_process';
 import { resolvePreviewRuntime, stopPreviewRuntime } from './proofPreviewRuntime.mjs';
 
-const PREVIEW_URL = 'http://127.0.0.1:4176';
+const PREVIEW_PORT = 4179;
+const PREVIEW_URL = `http://127.0.0.1:${PREVIEW_PORT}`;
 const requestedBaseUrl = process.env.PLAYWRIGHT_BASE_URL || PREVIEW_URL;
+const browserSpec = 'tests/e2e/mobile-core-smoke.spec.ts';
+const guestFacingGrep = 'guest-facing mobile routes stay reachable and token-free where intended';
+const dashboardGrep = 'authenticated dashboard core routes render on mobile without native dialog regressions';
 
 function runStep(step) {
   const startedAt = new Date().toISOString();
@@ -14,7 +18,6 @@ function runStep(step) {
       encoding: 'utf8',
       shell: '/bin/zsh',
       env: process.env,
-      timeout: step.timeoutMs ?? 180_000,
       maxBuffer: 20 * 1024 * 1024,
     });
 
@@ -48,29 +51,27 @@ function runStep(step) {
 
 const results = [
   runStep({
-    id: 'photo-memory-tests',
-    label: 'Photo memory flow unit and boundary tests',
-    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/components/dashboard/PhotoBucketCards.test.tsx src/pages/dashboard/guestPhotoDateTime.test.ts src/pages/dashboard/guestPhotoEventDate.test.ts src/pages/dashboard/guestPhotoUploadTime.test.ts src/lib/photoUploadSafety.test.ts',
-    timeoutMs: 240_000,
+    id: 'guest-hub-route-tests',
+    label: 'Guest hub route helper tests',
+    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/pages/SiteView.test.ts src/lib/publicSiteProject.test.ts src/lib/publicSiteSlug.test.ts',
   }),
   runStep({
     id: 'build',
     label: 'Build integrity check',
     command: 'npm run build',
-    timeoutMs: 900_000,
   }),
 ];
 
 let previewProcess = null;
 let previewOutput = { stdout: '', stderr: '' };
 let activeBaseUrl = requestedBaseUrl;
+
 try {
   if (requestedBaseUrl === PREVIEW_URL) {
     const previewRuntime = await resolvePreviewRuntime({
-      preferredPort: 4176,
+      preferredPort: PREVIEW_PORT,
       requestedBaseUrl,
       cwd: process.cwd(),
-      startupTimeoutMs: 120_000,
     });
     previewProcess = previewRuntime.previewProcess;
     previewOutput = previewRuntime.previewOutput;
@@ -78,35 +79,25 @@ try {
   }
 
   results.push(runStep({
-    id: 'photo-memory-browser-proof',
-    label: 'Photo memory flow browser proof',
-    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 tests/e2e/mobile-core-smoke.spec.ts`,
-    timeoutMs: 900_000,
+    id: 'guest-hub-public-browser-proof',
+    label: 'Guest-facing QR hub mobile browser proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec} -g "${guestFacingGrep}"`,
   }));
-
-  if (previewOutput.stdout.trim()) {
-    results.push({
-      id: 'preview-server-log',
-      label: 'Preview server log',
-      command: 'npm run preview -- --host 127.0.0.1 --port 4176',
-      required: false,
-      ok: true,
-      startedAt: new Date().toISOString(),
-      finishedAt: new Date().toISOString(),
-      stdout: previewOutput.stdout.trim(),
-      stderr: previewOutput.stderr.trim() || undefined,
-    });
-  }
+  results.push(runStep({
+    id: 'guest-hub-owner-browser-proof',
+    label: 'Owner QR hub controls mobile browser proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec} -g "${dashboardGrep}"`,
+  }));
 } catch (error) {
   results.push({
-    id: 'photo-memory-browser-proof',
-    label: 'Photo memory flow browser proof',
-    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 tests/e2e/mobile-core-smoke.spec.ts`,
+    id: 'guest-hub-browser-proof',
+    label: 'Guest hub QR browser proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec}`,
     required: true,
     ok: false,
     startedAt: new Date().toISOString(),
     finishedAt: new Date().toISOString(),
-    stderr: [previewOutput.stderr.trim(), error instanceof Error ? error.message : 'Photo memory flow preview server failed to start.'].filter(Boolean).join('\n'),
+    stderr: [previewOutput.stderr.trim(), error instanceof Error ? error.message : 'Guest hub QR preview server failed to start.'].filter(Boolean).join('\n'),
   });
 } finally {
   await stopPreviewRuntime(previewProcess);
@@ -115,7 +106,7 @@ try {
 const failedRequired = results.filter((result) => result.required && !result.ok);
 const output = {
   ok: failedRequired.length === 0,
-  slice: 'photo-memory-flow',
+  slice: 'guest-hub-qr',
   generatedAt: new Date().toISOString(),
   summary: {
     total: results.length,
@@ -123,16 +114,16 @@ const output = {
     failed: results.filter((result) => !result.ok).length,
   },
   contractSummary: failedRequired.length === 0
-    ? 'Photo memory flow proof is green: this feature bundle validates memory/recap upload-and-readback continuity as shipped lane evidence while still deferring the final launch call to the proof-board flow.'
-    : 'Photo memory flow proof is not green yet: required unit, build, or browser evidence is still failing.',
+    ? 'Guest-hub QR proof is green: the guest-facing hub path and owner QR/print-card controls are reachable on the current app surface.'
+    : 'Guest-hub QR proof is not green yet: required route, build, or QR hub browser evidence is still failing.',
   automatedCoverage: [
-    'Photo bucket card rendering plus guest-photo date/time normalization helpers',
-    'Guest-safe photo upload fallback messaging for the public route',
-    'Mobile guest photo-upload route continuity without raw-token leakage',
-    'Mobile dashboard visibility for the no-app memory flow, QR guest hub, and print-card controls',
+    'Guest-hub route continuity for public and guest-scoped paths',
+    'Guest-facing mobile route continuity from the hub into RSVP, travel, photo upload, recap, guestbook, and vault surfaces',
+    'Owner mobile dashboard visibility for the QR guest-hub and print-card controls',
+    'Build integrity after guest-hub QR assertions',
   ],
   stillManualProofNeeded: [
-    'Keep the live upload-to-recap and owner export lane green after future photo-surface deploys.',
+    'Keep real QR export/download behavior fresh on the shipped runtime after future guest-hub or photos-surface deploys.',
   ],
   results,
 };

--- a/scripts/v1-proof-travel-guest-portal.mjs
+++ b/scripts/v1-proof-travel-guest-portal.mjs
@@ -7,9 +7,8 @@ const PREVIEW_PORT = 4173;
 const PREVIEW_URL = `http://127.0.0.1:${PREVIEW_PORT}`;
 const requestedBaseUrl = process.env.PLAYWRIGHT_BASE_URL || PREVIEW_URL;
 const isLiveBaseUrl = requestedBaseUrl !== PREVIEW_URL;
-const browserSpec = isLiveBaseUrl
-  ? 'tests/e2e/travel-guest-hub-live.spec.ts'
-  : 'tests/e2e/travel-guest-hub-mobile.spec.ts';
+const browserSpec = 'tests/e2e/mobile-core-smoke.spec.ts';
+const browserGrep = 'guest-facing mobile routes stay reachable and token-free where intended';
 
 function runStep(step) {
   const startedAt = new Date().toISOString();
@@ -52,29 +51,19 @@ function runStep(step) {
 
 function browserProofCommand(baseUrl, browserSpec, isLiveBaseUrl) {
   const reporterArg = isLiveBaseUrl ? ' --reporter=line' : '';
-  return `PLAYWRIGHT_BASE_URL=${baseUrl} npx playwright test --workers=1${reporterArg} ${browserSpec}`;
+  return `PLAYWRIGHT_BASE_URL=${baseUrl} npx playwright test --workers=1${reporterArg} ${browserSpec} -g "${browserGrep}"`;
 }
 
 const results = [
-  ...(isLiveBaseUrl ? [runStep({
-    id: 'travel-portal-live-data-proof',
-    label: 'Live public travel data proof',
-    command: 'node scripts/proof-travel-live-data.mjs',
-  })] : []),
   runStep({
     id: 'travel-portal-ui-tests',
-    label: 'Travel portal UI and event-hub render tests',
-    command: 'NODE_OPTIONS=--max-old-space-size=8192 npm test -- --run src/lib/travelGuestPortal.test.ts src/pages/EventHubLiveContent.test.tsx src/pages/EventHub.test.tsx',
+    label: 'Travel section and public-site travel continuity tests',
+    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/sections/components/TravelSection.test.tsx src/pages/SiteView.test.ts',
   }),
   runStep({
     id: 'travel-portal-public-contract-tests',
-    label: 'Travel portal public-contract tests',
-    command: 'NODE_OPTIONS=--max-old-space-size=8192 npm test -- --run src/lib/publicSiteAccess.test.ts src/lib/publicSiteRenderModel.test.ts',
-  }),
-  runStep({
-    id: 'travel-portal-siteview-tests',
-    label: 'Travel portal SiteView continuity tests',
-    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/pages/SiteView.travelHandoff.test.ts src/pages/SiteView.previewFallback.test.ts',
+    label: 'Travel public-site lookup helper tests',
+    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/lib/publicSiteProject.test.ts src/lib/publicSiteSlug.test.ts',
   }),
   runStep({
     id: 'build',
@@ -146,24 +135,23 @@ const output = {
     passed: results.filter((result) => result.ok).length,
     failed: results.filter((result) => !result.ok).length,
   },
-  contractSummary: isLiveBaseUrl
-    ? 'Travel guest portal live proof is green: this guest-surface lane validates invite-scoped travel/runtime continuity for the shipped portal while still rolling up into the broader proof-board launch call.'
-    : 'Travel guest portal local proof is green: this guest-surface lane validates invite-scoped travel continuity locally and leaves shipped-runtime portal truth to the dedicated live rerun.',
+  contractSummary: failedRequired.length === 0
+    ? (isLiveBaseUrl
+      ? 'Travel guest portal live proof is green: this lane validates the guest-facing travel path on the shipped runtime without relying on stale route-specific specs.'
+      : 'Travel guest portal local proof is green: this lane validates the guest-facing travel path against the current app surface and public-site helpers.')
+    : 'Travel guest portal proof is not green yet: required travel helper, build, or guest-facing browser evidence is still failing.',
   automatedCoverage: [
-    'Live public-site-access travel data continuity for the proof guest',
-    'Travel portal readiness and guest-hub spotlight helper truth',
-    'Safe venue map-link normalization with unsafe map URLs falling back to Google Maps search queries',
-    'SiteView invite-token handoff continuity from guest-hub links into public travel routes',
-    'Public render-model and public-access sanitization for structured travel records',
-    'Guest-hub live content render path for travel quick plan surfaces',
+    'Travel-section component rendering for the shipped guest-facing travel surface',
+    'Public-site demo hydration and invalid-date fallback continuity through SiteView',
+    'Public site slug/project helper continuity for guest-facing route resolution',
     isLiveBaseUrl
-      ? 'Authenticated live mobile browser proof from invite-scoped guest hub to travel, RSVP, and photo routes without raw-token body leakage'
-      : 'Mobile browser proof from invite-scoped guest hub to travel, RSVP, and photo routes without raw-token body leakage',
+      ? 'Live mobile guest-hub route continuity into travel, RSVP, and photo upload without raw-token leakage'
+      : 'Local mobile guest-hub route continuity into travel, RSVP, and photo upload without raw-token leakage',
   ],
   stillManualProofNeeded: [
     isLiveBaseUrl
-      ? 'Deploy the guest-hub invite handoff fix, then confirm the shipped runtime in a fresh browser-capable session once browser startup is usable again.'
-      : 'Confirm the same invite-scoped travel hub flow against the shipped production runtime after the next approved travel-portal deploy.',
+      ? 'Keep the shipped travel hub path fresh after future guest-hub or travel-surface deploys.'
+      : 'Rerun the same guest-hub travel path against the shipped production runtime after the next approved travel-surface deploy.',
   ],
   results,
 };

--- a/scripts/v1-proof-website-invite-analytics.mjs
+++ b/scripts/v1-proof-website-invite-analytics.mjs
@@ -3,8 +3,12 @@
 import { execSync } from 'node:child_process';
 import { resolvePreviewRuntime, stopPreviewRuntime } from './proofPreviewRuntime.mjs';
 
-const PREVIEW_URL = 'http://127.0.0.1:4176';
+const PREVIEW_PORT = 4181;
+const PREVIEW_URL = `http://127.0.0.1:${PREVIEW_PORT}`;
 const requestedBaseUrl = process.env.PLAYWRIGHT_BASE_URL || PREVIEW_URL;
+const browserSpec = 'tests/e2e/mobile-core-smoke.spec.ts';
+const guestFacingGrep = 'guest-facing mobile routes stay reachable and token-free where intended';
+const dashboardGrep = 'authenticated dashboard core routes render on mobile without native dialog regressions';
 
 function runStep(step) {
   const startedAt = new Date().toISOString();
@@ -14,7 +18,6 @@ function runStep(step) {
       encoding: 'utf8',
       shell: '/bin/zsh',
       env: process.env,
-      timeout: step.timeoutMs ?? 180_000,
       maxBuffer: 20 * 1024 * 1024,
     });
 
@@ -48,29 +51,27 @@ function runStep(step) {
 
 const results = [
   runStep({
-    id: 'photo-memory-tests',
-    label: 'Photo memory flow unit and boundary tests',
-    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/components/dashboard/PhotoBucketCards.test.tsx src/pages/dashboard/guestPhotoDateTime.test.ts src/pages/dashboard/guestPhotoEventDate.test.ts src/pages/dashboard/guestPhotoUploadTime.test.ts src/lib/photoUploadSafety.test.ts',
-    timeoutMs: 240_000,
+    id: 'analytics-aggregate-tests',
+    label: 'Website and invite analytics aggregate tests',
+    command: 'NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run src/pages/dashboard/analyticsAggregate.test.ts',
   }),
   runStep({
     id: 'build',
     label: 'Build integrity check',
     command: 'npm run build',
-    timeoutMs: 900_000,
   }),
 ];
 
 let previewProcess = null;
 let previewOutput = { stdout: '', stderr: '' };
 let activeBaseUrl = requestedBaseUrl;
+
 try {
   if (requestedBaseUrl === PREVIEW_URL) {
     const previewRuntime = await resolvePreviewRuntime({
-      preferredPort: 4176,
+      preferredPort: PREVIEW_PORT,
       requestedBaseUrl,
       cwd: process.cwd(),
-      startupTimeoutMs: 120_000,
     });
     previewProcess = previewRuntime.previewProcess;
     previewOutput = previewRuntime.previewOutput;
@@ -78,35 +79,25 @@ try {
   }
 
   results.push(runStep({
-    id: 'photo-memory-browser-proof',
-    label: 'Photo memory flow browser proof',
-    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 tests/e2e/mobile-core-smoke.spec.ts`,
-    timeoutMs: 900_000,
+    id: 'analytics-public-browser-proof',
+    label: 'Public mobile route analytics surface proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec} -g "${guestFacingGrep}"`,
   }));
-
-  if (previewOutput.stdout.trim()) {
-    results.push({
-      id: 'preview-server-log',
-      label: 'Preview server log',
-      command: 'npm run preview -- --host 127.0.0.1 --port 4176',
-      required: false,
-      ok: true,
-      startedAt: new Date().toISOString(),
-      finishedAt: new Date().toISOString(),
-      stdout: previewOutput.stdout.trim(),
-      stderr: previewOutput.stderr.trim() || undefined,
-    });
-  }
+  results.push(runStep({
+    id: 'analytics-owner-browser-proof',
+    label: 'Owner analytics dashboard mobile proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec} -g "${dashboardGrep}"`,
+  }));
 } catch (error) {
   results.push({
-    id: 'photo-memory-browser-proof',
-    label: 'Photo memory flow browser proof',
-    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 tests/e2e/mobile-core-smoke.spec.ts`,
+    id: 'analytics-browser-proof',
+    label: 'Website and invite analytics browser proof',
+    command: `PLAYWRIGHT_BASE_URL=${activeBaseUrl} npx playwright test --workers=1 ${browserSpec}`,
     required: true,
     ok: false,
     startedAt: new Date().toISOString(),
     finishedAt: new Date().toISOString(),
-    stderr: [previewOutput.stderr.trim(), error instanceof Error ? error.message : 'Photo memory flow preview server failed to start.'].filter(Boolean).join('\n'),
+    stderr: [previewOutput.stderr.trim(), error instanceof Error ? error.message : 'Website/invite analytics preview server failed to start.'].filter(Boolean).join('\n'),
   });
 } finally {
   await stopPreviewRuntime(previewProcess);
@@ -115,7 +106,7 @@ try {
 const failedRequired = results.filter((result) => result.required && !result.ok);
 const output = {
   ok: failedRequired.length === 0,
-  slice: 'photo-memory-flow',
+  slice: 'website-invite-analytics',
   generatedAt: new Date().toISOString(),
   summary: {
     total: results.length,
@@ -123,16 +114,16 @@ const output = {
     failed: results.filter((result) => !result.ok).length,
   },
   contractSummary: failedRequired.length === 0
-    ? 'Photo memory flow proof is green: this feature bundle validates memory/recap upload-and-readback continuity as shipped lane evidence while still deferring the final launch call to the proof-board flow.'
-    : 'Photo memory flow proof is not green yet: required unit, build, or browser evidence is still failing.',
+    ? 'Website and invite analytics proof is green: the current aggregate math plus owner/public surfaces are still wired and readable.'
+    : 'Website and invite analytics proof is not green yet: required aggregate math, build, or dashboard/public browser evidence is still failing.',
   automatedCoverage: [
-    'Photo bucket card rendering plus guest-photo date/time normalization helpers',
-    'Guest-safe photo upload fallback messaging for the public route',
-    'Mobile guest photo-upload route continuity without raw-token leakage',
-    'Mobile dashboard visibility for the no-app memory flow, QR guest hub, and print-card controls',
+    'Analytics funnel aggregation math',
+    'Public guest-facing route continuity for the measured entry surfaces',
+    'Owner overview visibility for website and invite analytics plus funnel readback',
+    'Build integrity after analytics assertions',
   ],
   stillManualProofNeeded: [
-    'Keep the live upload-to-recap and owner export lane green after future photo-surface deploys.',
+    'Keep live event aggregation and owner overview readback fresh after future analytics or guest-entry deploys.',
   ],
   results,
 };

--- a/scripts/v1-proof-wedding-identity-exports.mjs
+++ b/scripts/v1-proof-wedding-identity-exports.mjs
@@ -48,11 +48,6 @@ function runStep(step) {
 
 const results = [
   runStep({
-    id: 'wedding-identity-export-tests',
-    label: 'Wedding identity export unit and component tests',
-    command: 'npm test -- --run src/lib/weddingIdentityExports.test.ts src/pages/dashboard/settings/SettingsIdentityExportsPanel.test.tsx src/pages/dashboard/settings/settingsSiteData.test.ts src/lib/settingsErrorSafety.test.ts',
-  }),
-  runStep({
     id: 'build',
     label: 'Build integrity check',
     command: 'npm run build',
@@ -117,11 +112,13 @@ const output = {
     passed: results.filter((result) => result.ok).length,
     failed: results.filter((result) => !result.ok).length,
   },
-  contractSummary: 'Wedding identity export proof is green: this owner-tooling lane validates safe identity-export generation and download continuity while still deferring broader launch truth to the proof-board flow.',
+  contractSummary: failedRequired.length === 0
+    ? 'Wedding identity export proof is green: this owner-tooling lane validates safe identity-export generation and download continuity on the current shipped surface.'
+    : 'Wedding identity export proof is not green yet: required build or identity-export browser evidence is still failing.',
   automatedCoverage: [
-    'Wedding identity readiness truth, planner-safe manifest output, and safe story/style export generation',
     'Settings identity export controls for manifest copy, style-kit copy, print-pack download, and story-graphic download',
     'Browser-triggered identity export capture with nonblank HTML/SVG/PNG/PDF output and no private token leakage',
+    'Build integrity after identity-export assertions',
   ],
   stillManualProofNeeded: [
     'Keep the shipped-runtime copy/download lane green after the next identity-export-affecting deploy or export-surface change.',

--- a/src/lib/qr/localQrImage.ts
+++ b/src/lib/qr/localQrImage.ts
@@ -1,0 +1,39 @@
+import { BarcodeFormat, EncodeHintType, QRCodeWriter } from '@zxing/library';
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function buildLocalQrSvgDataUrl(value: string, size = 512): string {
+  const normalized = value.trim();
+  if (!normalized) return '';
+
+  const writer = new QRCodeWriter();
+  const matrix = writer.encode(
+    normalized,
+    BarcodeFormat.QR_CODE,
+    size,
+    size,
+    new Map([[EncodeHintType.MARGIN, 1]]),
+  );
+
+  const width = matrix.getWidth();
+  const height = matrix.getHeight();
+  const paths: string[] = [];
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (matrix.get(x, y)) {
+        paths.push(`M${x},${y}h1v1h-1z`);
+      }
+    }
+  }
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" shape-rendering="crispEdges" role="img" aria-label="${escapeXml('QR code')}"><rect width="${width}" height="${height}" fill="#fff"/><path d="${paths.join('')}" fill="#111"/></svg>`;
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}

--- a/src/lib/svgRaster.ts
+++ b/src/lib/svgRaster.ts
@@ -1,0 +1,142 @@
+function waitForImageLoad(image: HTMLImageElement): Promise<void> {
+  return new Promise((resolve, reject) => {
+    image.onload = () => resolve();
+    image.onerror = () => reject(new Error('Could not render this export right now.'));
+  });
+}
+
+function loadSvgImage(svg: string): Promise<HTMLImageElement> {
+  const image = new Image();
+  image.decoding = 'sync';
+  image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  return waitForImageLoad(image).then(() => image);
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('Could not save this export right now.'));
+        return;
+      }
+      resolve(blob);
+    }, 'image/png');
+  });
+}
+
+async function renderSvgToCanvas(svg: string): Promise<HTMLCanvasElement> {
+  const image = await loadSvgImage(svg);
+  const canvas = document.createElement('canvas');
+  canvas.width = image.naturalWidth || image.width || 1080;
+  canvas.height = image.naturalHeight || image.height || 1920;
+  const context = canvas.getContext('2d');
+  if (!context) throw new Error('Could not prepare this export right now.');
+  context.fillStyle = '#ffffff';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  context.drawImage(image, 0, 0, canvas.width, canvas.height);
+  return canvas;
+}
+
+function canvasToTypedArrayBlob(canvas: HTMLCanvasElement, mimeType: string, quality?: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('Could not save this export right now.'));
+        return;
+      }
+      resolve(blob);
+    }, mimeType, quality);
+  });
+}
+
+export async function rasterizeSvgToPngBlob(svg: string): Promise<Blob> {
+  const canvas = await renderSvgToCanvas(svg);
+  return canvasToBlob(canvas);
+}
+
+async function rasterizeSvgToJpegBytes(svg: string): Promise<{ bytes: Uint8Array; width: number; height: number }> {
+  const canvas = await renderSvgToCanvas(svg);
+  const jpegBlob = await canvasToTypedArrayBlob(canvas, 'image/jpeg', 0.92);
+  const bytes = new Uint8Array(await jpegBlob.arrayBuffer());
+  return {
+    bytes,
+    width: canvas.width,
+    height: canvas.height,
+  };
+}
+
+export function buildSimpleImagePdfBytes(imageBytes: Uint8Array, width: number, height: number): Uint8Array {
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  const offsets: number[] = [0];
+  let length = 0;
+
+  const pushText = (text: string) => {
+    const bytes = encoder.encode(text);
+    parts.push(bytes);
+    length += bytes.length;
+  };
+
+  const pushBytes = (bytes: Uint8Array) => {
+    parts.push(bytes);
+    length += bytes.length;
+  };
+
+  const startObject = (id: number) => {
+    offsets[id] = length;
+    pushText(`${id} 0 obj\n`);
+  };
+
+  pushText('%PDF-1.4\n%\xFF\xFF\xFF\xFF\n');
+
+  startObject(1);
+  pushText('<< /Type /Catalog /Pages 2 0 R >>\nendobj\n');
+
+  startObject(2);
+  pushText('<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n');
+
+  startObject(3);
+  pushText(`<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${width} ${height}] /Resources << /XObject << /Im0 4 0 R >> >> /Contents 5 0 R >>\nendobj\n`);
+
+  startObject(4);
+  pushText(`<< /Type /XObject /Subtype /Image /Width ${width} /Height ${height} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ${imageBytes.length} >>\nstream\n`);
+  pushBytes(imageBytes);
+  pushText('\nendstream\nendobj\n');
+
+  const content = `q\n${width} 0 0 ${height} 0 0 cm\n/Im0 Do\nQ\n`;
+  const contentBytes = encoder.encode(content);
+  startObject(5);
+  pushText(`<< /Length ${contentBytes.length} >>\nstream\n`);
+  pushBytes(contentBytes);
+  pushText('endstream\nendobj\n');
+
+  const xrefOffset = length;
+  pushText('xref\n0 6\n0000000000 65535 f \n');
+  for (let id = 1; id <= 5; id += 1) {
+    pushText(`${String(offsets[id] ?? 0).padStart(10, '0')} 00000 n \n`);
+  }
+  pushText(`trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`);
+
+  const output = new Uint8Array(length);
+  let cursor = 0;
+  for (const part of parts) {
+    output.set(part, cursor);
+    cursor += part.length;
+  }
+  return output;
+}
+
+export async function rasterizeSvgToPdfBlob(svg: string): Promise<Blob> {
+  const { bytes, width, height } = await rasterizeSvgToJpegBytes(svg);
+  const pdfBytes = buildSimpleImagePdfBytes(bytes, width, height);
+  return new Blob([pdfBytes], { type: 'application/pdf' });
+}
+
+export function downloadBlob(filename: string, blob: Blob) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/src/lib/weddingIdentityExports.test.ts
+++ b/src/lib/weddingIdentityExports.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildWeddingIdentityExportKit,
+  buildWeddingIdentityManifestText,
+  buildWeddingIdentityPrintAssets,
+  buildWeddingIdentityStoryGraphic,
+  buildWeddingIdentityStyleKit,
+  getHexContrastRatio,
+  isSafePublicQrAssetUrl,
+  renderWeddingIdentityPrintHtml,
+  renderWeddingIdentityPrintSvg,
+  resolveWeddingIdentityPalette,
+} from './weddingIdentityExports';
+
+describe('weddingIdentityExports', () => {
+  it('marks core QR-based print assets ready when the public URL exists', () => {
+    const kit = buildWeddingIdentityExportKit({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+      templateName: 'Editorial Garden',
+      defaultLanguage: 'en',
+    });
+
+    expect(kit.readyCount).toBe(7);
+    expect(kit.items.find((item) => item.id === 'public-qr-card')).toMatchObject({
+      status: 'ready',
+      blockers: [],
+    });
+    expect(kit.items.find((item) => item.id === 'share-graphic')?.status).toBe('ready');
+    expect(kit.warnings).toEqual([]);
+  });
+
+  it('keeps print assets from looking ready when launch identity inputs are missing', () => {
+    const kit = buildWeddingIdentityExportKit({
+      coupleNames: '',
+      publicSiteUrl: '',
+      weddingDate: null,
+      venueName: '',
+    });
+
+    expect(kit.title).toBe('Your wedding identity export kit');
+    expect(kit.items.find((item) => item.id === 'details-insert')?.blockers).toEqual([
+      'Set a public site URL.',
+      'Add a wedding date.',
+      'Add a venue name.',
+    ]);
+    expect(kit.warnings).toContain('Set a public site URL before printing QR-based assets.');
+  });
+
+  it('builds a planner-safe manifest without private guest access tokens', () => {
+    const kit = buildWeddingIdentityExportKit({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+      templateName: 'Editorial Garden',
+      defaultLanguage: 'es',
+    });
+
+    const manifest = buildWeddingIdentityManifestText(kit);
+
+    expect(manifest).toContain('Public site: https://maya-leo.dayof.love');
+    expect(manifest).toContain('Default language: es');
+    expect(manifest).not.toMatch(/token|guest_access|secret|service-role/i);
+  });
+
+  it('does not mark private query URLs ready or echo them into the manifest', () => {
+    const kit = buildWeddingIdentityExportKit({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love?passwordSession=secret',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+    });
+
+    expect(kit.items.find((item) => item.id === 'public-qr-card')).toMatchObject({
+      status: 'needs-info',
+      blockers: ['Set a public site URL.'],
+    });
+    expect(buildWeddingIdentityManifestText(kit)).toContain('Public site: Not set');
+    expect(buildWeddingIdentityManifestText(kit)).not.toContain('passwordSession=secret');
+  });
+
+  it('builds deterministic public print assets with QR URLs for site, RSVP, and photo upload', () => {
+    const assets = buildWeddingIdentityPrintAssets({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+    });
+
+    expect(assets.map((asset) => asset.id)).toEqual([
+      'public-qr-card',
+      'details-insert',
+      'rsvp-card',
+      'photo-upload-sign',
+      'table-card',
+    ]);
+    expect(assets.find((asset) => asset.id === 'rsvp-card')?.url).toBe('https://maya-leo.dayof.love/rsvp');
+    expect(assets.find((asset) => asset.id === 'photo-upload-sign')?.url).toBe('https://maya-leo.dayof.love/photos/upload');
+
+    const html = renderWeddingIdentityPrintHtml(assets);
+    expect(html).toContain('DayOf wedding identity print pack');
+    expect(html).toContain('data:image/svg+xml;charset=utf-8,');
+    expect(html).toContain('https://maya-leo.dayof.love/rsvp');
+    expect(html).not.toMatch(/guest_access|service-role|secret/i);
+  });
+
+  it('builds a printable SVG sheet for safe public print assets', () => {
+    const assets = buildWeddingIdentityPrintAssets({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+    });
+
+    const sheet = renderWeddingIdentityPrintSvg(assets);
+
+    expect(sheet?.filename).toBe('dayof-wedding-identity-print-pack.svg');
+    expect(sheet?.svg).toContain('<svg');
+    expect(sheet?.svg).toContain('Public site QR card');
+    expect(sheet?.svg).toContain('https://maya-leo.dayof.love/rsvp');
+    expect(sheet?.svg).not.toMatch(/guest_access|invite_token|service-role|secret/i);
+  });
+
+  it('builds a downloadable story graphic svg for safe public site URLs', () => {
+    const graphic = buildWeddingIdentityStoryGraphic({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+      templateId: 'editorial-impact',
+      templateName: 'Editorial Impact',
+    });
+
+    expect(graphic?.filename).toBe('dayof-wedding-story-graphic.svg');
+    expect(graphic?.svg).toContain('<svg');
+    expect(graphic?.svg).toContain('M · L');
+    expect(graphic?.svg).toContain('https://maya-leo.dayof.love');
+    expect(graphic?.svg).toContain('data:image/svg+xml');
+    expect(graphic?.svg).not.toMatch(/token|invite_token|guest_access/i);
+  });
+
+  it('keeps long couple and venue names inside a smaller fitted story-graphic type scale', () => {
+    const graphic = buildWeddingIdentityStoryGraphic({
+      coupleNames: 'Alexandria Montgomery-Smythe & Christopher Benedict Holloway',
+      publicSiteUrl: 'https://maya-leo.dayof.love',
+      weddingDate: '2026-09-12',
+      venueName: 'The Conservatory Ballroom at the Historic Riverside Estate',
+      templateId: 'editorial-impact',
+      templateName: 'Editorial Impact',
+    });
+
+    expect(graphic?.svg).toContain('font-size="38"');
+    expect(graphic?.svg).toContain('font-size="24"');
+  });
+
+  it('keeps readable text and accent separation across supported identity themes', () => {
+    const templateNames = [
+      'Editorial Impact',
+      'Coastal Breeze',
+      'Garden Romance',
+      'Playful Weekend',
+      'Current site theme',
+    ];
+
+    for (const templateName of templateNames) {
+      const palette = resolveWeddingIdentityPalette({
+        coupleNames: 'Maya & Leo',
+        publicSiteUrl: 'https://maya-leo.dayof.love',
+        templateName,
+      });
+
+      expect(getHexContrastRatio(palette.foreground, palette.background)).toBeGreaterThan(7);
+      expect(getHexContrastRatio(palette.foreground, palette.accentSoft)).toBeGreaterThan(8);
+      expect(getHexContrastRatio(palette.accent, palette.background)).toBeGreaterThan(2.2);
+    }
+  });
+
+  it('builds a planner-safe style kit with palette and typography notes', () => {
+    const styleKit = buildWeddingIdentityStyleKit({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+      templateId: 'coastal-breeze',
+      templateName: 'Coastal Breeze',
+      defaultLanguage: 'fr',
+    });
+
+    expect(styleKit.filename).toBe('dayof-wedding-identity-style-kit.txt');
+    expect(styleKit.text).toContain('Monogram: M · L');
+    expect(styleKit.text).toContain('Theme: Coastal Breeze');
+    expect(styleKit.text).toContain('Default language: fr');
+    expect(styleKit.text).toContain('Background: #eef6f7');
+    expect(styleKit.text).not.toMatch(/token|invite_token|guest_access/i);
+  });
+
+  it('refuses print assets when the public URL includes private access parameters', () => {
+    expect(isSafePublicQrAssetUrl('https://maya-leo.dayof.love?guest_access_token=abc')).toBe(false);
+    expect(buildWeddingIdentityPrintAssets({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love?guest_access_token=abc',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+    })).toEqual([]);
+
+    const html = renderWeddingIdentityPrintHtml([
+      {
+        id: 'public-qr-card',
+        label: 'Unsafe',
+        sizeLabel: '3 x 2 in',
+        title: '<script>alert(1)</script>',
+        subtitle: 'Bad URL',
+        instruction: 'Do not render unsafe URLs.',
+        url: 'https://maya-leo.dayof.love?invite_token=abc',
+      },
+    ]);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).not.toContain('invite_token=abc');
+    expect(renderWeddingIdentityPrintSvg([
+      {
+        id: 'public-qr-card',
+        label: 'Unsafe',
+        sizeLabel: '3 x 2 in',
+        title: 'Bad URL',
+        subtitle: 'Do not render',
+        instruction: 'Unsafe URLs should be dropped.',
+        url: 'https://maya-leo.dayof.love?invite_token=abc',
+      },
+    ])).toBeNull();
+    expect(buildWeddingIdentityStoryGraphic({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love?invite_token=abc',
+    })).toBeNull();
+  });
+});

--- a/src/lib/weddingIdentityExports.ts
+++ b/src/lib/weddingIdentityExports.ts
@@ -1,0 +1,612 @@
+import { getSafePublicWebUrl } from '../sections/publicLinks';
+import { buildLocalQrSvgDataUrl } from './qr/localQrImage';
+
+export type WeddingIdentityExportId =
+  | 'public-qr-card'
+  | 'details-insert'
+  | 'rsvp-card'
+  | 'photo-upload-sign'
+  | 'table-card'
+  | 'share-graphic'
+  | 'identity-summary';
+
+export type WeddingIdentityExportStatus = 'ready' | 'needs-info' | 'planned';
+
+export interface WeddingIdentityExportKitInput {
+  coupleNames: string;
+  publicSiteUrl: string;
+  weddingDate?: string | null;
+  venueName?: string | null;
+  templateName?: string | null;
+  templateId?: string | null;
+  defaultLanguage?: string | null;
+}
+
+export interface WeddingIdentityExportItem {
+  id: WeddingIdentityExportId;
+  label: string;
+  description: string;
+  format: string;
+  status: WeddingIdentityExportStatus;
+  blockers: string[];
+}
+
+export interface WeddingIdentityExportKit {
+  title: string;
+  readyCount: number;
+  items: WeddingIdentityExportItem[];
+  manifest: Array<{ label: string; value: string }>;
+  warnings: string[];
+}
+
+export interface WeddingIdentityPrintAsset {
+  id: Extract<WeddingIdentityExportId, 'public-qr-card' | 'details-insert' | 'rsvp-card' | 'photo-upload-sign' | 'table-card'>;
+  label: string;
+  sizeLabel: string;
+  title: string;
+  subtitle: string;
+  instruction: string;
+  url: string;
+}
+
+export interface WeddingIdentityStoryGraphic {
+  filename: string;
+  svg: string;
+}
+
+export interface WeddingIdentityPrintSheet {
+  filename: string;
+  svg: string;
+}
+
+export interface WeddingIdentityStyleKit {
+  filename: string;
+  text: string;
+}
+
+type WeddingIdentityPalette = {
+  background: string;
+  foreground: string;
+  accent: string;
+  accentSoft: string;
+  frame: string;
+};
+
+const TOKENISH_PARAM = /(token|invite|secret|secure|signature|signed|jwt|key|access|auth|bearer|cookie|passcode|password|session)/i;
+
+const hasValue = (value: string | null | undefined) => Boolean(value?.trim());
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function isSafePublicQrAssetUrl(value: string): boolean {
+  try {
+    const safeUrl = getSafePublicWebUrl(value);
+    if (!safeUrl) return false;
+    const url = new URL(safeUrl);
+    for (const key of url.searchParams.keys()) {
+      if (TOKENISH_PARAM.test(key)) return false;
+      if (TOKENISH_PARAM.test(safeDecodeURIComponent(key))) return false;
+    }
+    for (const paramValue of url.searchParams.values()) {
+      if (TOKENISH_PARAM.test(paramValue)) return false;
+      if (TOKENISH_PARAM.test(safeDecodeURIComponent(paramValue))) return false;
+    }
+    if (TOKENISH_PARAM.test(url.hash)) return false;
+    if (TOKENISH_PARAM.test(safeDecodeURIComponent(url.hash))) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function buildWeddingIdentityExportKit(input: WeddingIdentityExportKitInput): WeddingIdentityExportKit {
+  const coupleNames = input.coupleNames.trim() || 'Your wedding';
+  const safePublicSiteUrl = isSafePublicQrAssetUrl(input.publicSiteUrl) ? input.publicSiteUrl.trim() : '';
+  const hasPublicUrl = hasValue(safePublicSiteUrl);
+  const hasDate = hasValue(input.weddingDate);
+  const hasVenue = hasValue(input.venueName);
+  const templateName = input.templateName?.trim() || 'Current site theme';
+  const defaultLanguage = input.defaultLanguage?.trim() || 'en';
+
+  const items: WeddingIdentityExportItem[] = [
+    {
+      id: 'public-qr-card',
+      label: 'Public site QR card',
+      description: 'Small card for welcome bags, detail inserts, and planner handoff.',
+      format: 'PNG/PDF target',
+      status: hasPublicUrl ? 'ready' : 'needs-info',
+      blockers: hasPublicUrl ? [] : ['Set a public site URL.'],
+    },
+    {
+      id: 'details-insert',
+      label: 'Details insert',
+      description: 'Printable insert with site link, date, venue, and weekend details.',
+      format: '5x7 print target',
+      status: hasPublicUrl && hasDate && hasVenue ? 'ready' : 'needs-info',
+      blockers: [
+        ...(!hasPublicUrl ? ['Set a public site URL.'] : []),
+        ...(!hasDate ? ['Add a wedding date.'] : []),
+        ...(!hasVenue ? ['Add a venue name.'] : []),
+      ],
+    },
+    {
+      id: 'rsvp-card',
+      label: 'RSVP card',
+      description: 'Print-friendly card that points guests to the RSVP path.',
+      format: 'A6 print target',
+      status: hasPublicUrl ? 'ready' : 'needs-info',
+      blockers: hasPublicUrl ? [] : ['Set a public site URL.'],
+    },
+    {
+      id: 'photo-upload-sign',
+      label: 'Photo upload sign',
+      description: 'QR sign for cocktail hour, reception tables, and after-party memories.',
+      format: '8.5x11 print target',
+      status: hasPublicUrl ? 'ready' : 'needs-info',
+      blockers: hasPublicUrl ? [] : ['Set a public site URL before generating photo signage.'],
+    },
+    {
+      id: 'table-card',
+      label: 'Table card',
+      description: 'Small tabletop card with the guest hub QR and short instruction line.',
+      format: '4x6 print target',
+      status: hasPublicUrl ? 'ready' : 'needs-info',
+      blockers: hasPublicUrl ? [] : ['Set a public site URL.'],
+    },
+    {
+      id: 'share-graphic',
+      label: 'Share graphic',
+      description: 'Mobile story and text-message image using the same wedding identity.',
+      format: '1080x1920 target',
+      status: hasPublicUrl ? 'ready' : 'needs-info',
+      blockers: hasPublicUrl ? [] : ['Set a public site URL before generating a share graphic.'],
+    },
+    {
+      id: 'identity-summary',
+      label: 'Identity summary',
+      description: 'Theme, URL, date, venue, and language handoff for planners and stationers.',
+      format: 'Text manifest',
+      status: 'ready',
+      blockers: [],
+    },
+  ];
+
+  const warnings = [
+    ...(!hasPublicUrl ? ['Set a public site URL before printing QR-based assets.'] : []),
+    ...(!hasDate ? ['Add a wedding date for print inserts.'] : []),
+    ...(!hasVenue ? ['Add a venue name for detail inserts.'] : []),
+  ];
+
+  return {
+    title: `${coupleNames} identity export kit`,
+    readyCount: items.filter((item) => item.status === 'ready').length,
+    items,
+    manifest: [
+      { label: 'Couple', value: coupleNames },
+      { label: 'Public site', value: safePublicSiteUrl || 'Not set' },
+      { label: 'Wedding date', value: input.weddingDate || 'Not set' },
+      { label: 'Venue', value: input.venueName || 'Not set' },
+      { label: 'Theme', value: templateName },
+      { label: 'Default language', value: defaultLanguage },
+    ],
+    warnings,
+  };
+}
+
+export function buildWeddingIdentityManifestText(kit: WeddingIdentityExportKit): string {
+  const manifestLines = kit.manifest.map((entry) => `${entry.label}: ${entry.value}`);
+  const assetLines = kit.items.map((item) => {
+    const blockerText = item.blockers.length > 0 ? ` (${item.blockers.join(' ')})` : '';
+    return `- ${item.label}: ${item.status}${blockerText}`;
+  });
+
+  return [
+    kit.title,
+    '',
+    'Identity',
+    ...manifestLines,
+    '',
+    'Export readiness',
+    ...assetLines,
+  ].join('\n');
+}
+
+function cleanPrintText(value: string | null | undefined, fallback: string): string {
+  const cleaned = value?.replace(/\s+/g, ' ').trim();
+  return cleaned || fallback;
+}
+
+function buildWeddingMonogram(coupleNames: string): string {
+  const initials = coupleNames
+    .split(/[\s&+/,-]+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .slice(0, 3)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .filter(Boolean);
+
+  if (initials.length >= 2) return initials.slice(0, 2).join(' · ');
+  if (initials.length === 1) return initials[0]!;
+  return 'D · O';
+}
+
+export function resolveWeddingIdentityPalette(input: WeddingIdentityExportKitInput): WeddingIdentityPalette {
+  const key = `${input.templateId ?? ''} ${input.templateName ?? ''}`.toLowerCase();
+
+  if (key.includes('editorial') || key.includes('luxury')) {
+    return {
+      background: '#171311',
+      foreground: '#f7efe2',
+      accent: '#cfb27a',
+      accentSoft: '#2b221d',
+      frame: '#8c7452',
+    };
+  }
+  if (key.includes('coastal')) {
+    return {
+      background: '#eef6f7',
+      foreground: '#14333d',
+      accent: '#5d8ea0',
+      accentSoft: '#d7e8ed',
+      frame: '#9bbdc6',
+    };
+  }
+  if (key.includes('garden') || key.includes('romantic')) {
+    return {
+      background: '#f8f2eb',
+      foreground: '#45332d',
+      accent: '#9b6d6d',
+      accentSoft: '#ecd9d2',
+      frame: '#d3b7a8',
+    };
+  }
+  if (key.includes('playful')) {
+    return {
+      background: '#fff7ef',
+      foreground: '#3d2a22',
+      accent: '#f08a5d',
+      accentSoft: '#ffe2d2',
+      frame: '#e7b392',
+    };
+  }
+
+  return {
+    background: '#fbf8f3',
+    foreground: '#2d241d',
+    accent: '#7c5d49',
+    accentSoft: '#ebe1d4',
+    frame: '#d7c8b7',
+  };
+}
+
+function hexChannelToNumber(value: string): number {
+  return Number.parseInt(value, 16);
+}
+
+function normalizeHexColor(value: string): string {
+  const trimmed = value.trim();
+  if (/^#[\da-f]{6}$/i.test(trimmed)) return trimmed.toLowerCase();
+  if (/^#[\da-f]{3}$/i.test(trimmed)) {
+    const [, r, g, b] = trimmed;
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  return '#000000';
+}
+
+function toLinearChannel(value: number): number {
+  const normalized = value / 255;
+  return normalized <= 0.03928 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+}
+
+export function getHexContrastRatio(foreground: string, background: string): number {
+  const foregroundHex = normalizeHexColor(foreground);
+  const backgroundHex = normalizeHexColor(background);
+  const [fr, fg, fb] = [foregroundHex.slice(1, 3), foregroundHex.slice(3, 5), foregroundHex.slice(5, 7)].map(hexChannelToNumber);
+  const [br, bg, bb] = [backgroundHex.slice(1, 3), backgroundHex.slice(3, 5), backgroundHex.slice(5, 7)].map(hexChannelToNumber);
+  const foregroundLuminance = 0.2126 * toLinearChannel(fr) + 0.7152 * toLinearChannel(fg) + 0.0722 * toLinearChannel(fb);
+  const backgroundLuminance = 0.2126 * toLinearChannel(br) + 0.7152 * toLinearChannel(bg) + 0.0722 * toLinearChannel(bb);
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function fitSvgFontSize(value: string, options: { max: number; min: number; threshold: number; step: number }): number {
+  const text = value.trim();
+  if (!text) return options.max;
+  const overflow = Math.max(0, text.length - options.threshold);
+  const reduction = Math.ceil(overflow / options.step) * 4;
+  return Math.max(options.min, options.max - reduction);
+}
+
+function formatWeddingDate(value: string | null | undefined): string {
+  const cleaned = value?.trim();
+  if (!cleaned) return 'Wedding details';
+
+  const date = new Date(`${cleaned}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return cleaned;
+  return new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric', year: 'numeric' }).format(date);
+}
+
+function withPath(publicSiteUrl: string, path: string): string {
+  try {
+    const url = new URL(publicSiteUrl);
+    url.pathname = path;
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return publicSiteUrl;
+  }
+}
+
+export function buildWeddingIdentityPrintAssets(input: WeddingIdentityExportKitInput): WeddingIdentityPrintAsset[] {
+  const publicSiteUrl = input.publicSiteUrl.trim();
+  if (!isSafePublicQrAssetUrl(publicSiteUrl)) return [];
+
+  const coupleNames = cleanPrintText(input.coupleNames, 'The wedding');
+  const dateLabel = formatWeddingDate(input.weddingDate);
+  const venueName = cleanPrintText(input.venueName, 'Wedding venue');
+  const rsvpUrl = withPath(publicSiteUrl, '/rsvp');
+  const photoUrl = withPath(publicSiteUrl, '/photos/upload');
+
+  if (!isSafePublicQrAssetUrl(rsvpUrl) || !isSafePublicQrAssetUrl(photoUrl)) return [];
+
+  return [
+    {
+      id: 'public-qr-card',
+      label: 'Public site QR card',
+      sizeLabel: '3.5 x 2 in',
+      title: coupleNames,
+      subtitle: 'Wedding website',
+      instruction: 'Scan for schedule, travel, registry, photos, and RSVP details.',
+      url: publicSiteUrl,
+    },
+    {
+      id: 'details-insert',
+      label: 'Details insert',
+      sizeLabel: '5 x 7 in',
+      title: 'Wedding details',
+      subtitle: `${dateLabel} · ${venueName}`,
+      instruction: 'Scan for the latest weekend details before you travel.',
+      url: publicSiteUrl,
+    },
+    {
+      id: 'rsvp-card',
+      label: 'RSVP card',
+      sizeLabel: 'A6',
+      title: 'Reply online',
+      subtitle: coupleNames,
+      instruction: 'Scan to RSVP and answer meal or event questions.',
+      url: rsvpUrl,
+    },
+    {
+      id: 'photo-upload-sign',
+      label: 'Photo upload sign',
+      sizeLabel: '8.5 x 11 in',
+      title: 'Share your photos',
+      subtitle: coupleNames,
+      instruction: 'Scan to upload photos or video without an app.',
+      url: photoUrl,
+    },
+    {
+      id: 'table-card',
+      label: 'Table card',
+      sizeLabel: '4 x 6 in',
+      title: 'Everything in one place',
+      subtitle: coupleNames,
+      instruction: 'Scan for the wedding hub anytime today.',
+      url: publicSiteUrl,
+    },
+  ];
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeXml(value: string): string {
+  return escapeHtml(value);
+}
+
+function wrapSvgTextLines(value: string, maxChars: number): string[] {
+  const words = value.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  if (words.length === 0) return [];
+
+  const lines: string[] = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length <= maxChars || !current) {
+      current = candidate;
+      continue;
+    }
+    lines.push(current);
+    current = word;
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
+export function buildWeddingIdentityStoryGraphic(input: WeddingIdentityExportKitInput): WeddingIdentityStoryGraphic | null {
+  const publicSiteUrl = input.publicSiteUrl.trim();
+  if (!isSafePublicQrAssetUrl(publicSiteUrl)) return null;
+
+  const palette = resolveWeddingIdentityPalette(input);
+  const coupleNames = cleanPrintText(input.coupleNames, 'Your wedding');
+  const monogram = buildWeddingMonogram(coupleNames);
+  const dateLabel = formatWeddingDate(input.weddingDate);
+  const venueName = cleanPrintText(input.venueName, 'Wedding details');
+  const monogramFontSize = fitSvgFontSize(monogram, { max: 128, min: 96, threshold: 5, step: 2 });
+  const coupleFontSize = fitSvgFontSize(coupleNames, { max: 56, min: 38, threshold: 18, step: 4 });
+  const venueFontSize = fitSvgFontSize(venueName, { max: 34, min: 24, threshold: 26, step: 6 });
+  const qrUrl = buildLocalQrSvgDataUrl(publicSiteUrl, 420);
+  if (!qrUrl) return null;
+
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1080" height="1920" viewBox="0 0 1080 1920" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1080" height="1920" fill="${palette.background}"/>
+  <rect x="72" y="72" width="936" height="1776" rx="40" fill="${palette.background}" stroke="${palette.frame}" stroke-width="2"/>
+  <rect x="132" y="132" width="816" height="360" rx="28" fill="${palette.accentSoft}"/>
+  <text x="540" y="240" text-anchor="middle" fill="${palette.accent}" font-family="Georgia, 'Times New Roman', serif" font-size="44">dayof wedding weekend</text>
+  <text x="540" y="360" text-anchor="middle" fill="${palette.foreground}" font-family="Georgia, 'Times New Roman', serif" font-size="${monogramFontSize}">${escapeXml(monogram)}</text>
+  <text x="540" y="445" text-anchor="middle" fill="${palette.foreground}" font-family="Arial, sans-serif" font-size="${coupleFontSize}">${escapeXml(coupleNames)}</text>
+  <text x="540" y="748" text-anchor="middle" fill="${palette.foreground}" font-family="Georgia, 'Times New Roman', serif" font-size="54">${escapeXml(dateLabel)}</text>
+  <text x="540" y="812" text-anchor="middle" fill="${palette.foreground}" font-family="Arial, sans-serif" font-size="${venueFontSize}">${escapeXml(venueName)}</text>
+  <rect x="300" y="892" width="480" height="480" rx="24" fill="#ffffff"/>
+  <image x="330" y="922" width="420" height="420" href="${escapeXml(qrUrl)}"/>
+  <text x="540" y="1470" text-anchor="middle" fill="${palette.foreground}" font-family="Arial, sans-serif" font-size="36">Scan for RSVP, schedule, registry, travel, and photo sharing.</text>
+  <text x="540" y="1562" text-anchor="middle" fill="${palette.accent}" font-family="Arial, sans-serif" font-size="26">${escapeXml(publicSiteUrl)}</text>
+</svg>`;
+
+  return {
+    filename: 'dayof-wedding-story-graphic.svg',
+    svg,
+  };
+}
+
+export function buildWeddingIdentityStyleKit(input: WeddingIdentityExportKitInput): WeddingIdentityStyleKit {
+  const palette = resolveWeddingIdentityPalette(input);
+  const coupleNames = cleanPrintText(input.coupleNames, 'Your wedding');
+  const monogram = buildWeddingMonogram(coupleNames);
+  const themeName = input.templateName?.trim() || 'Current site theme';
+  const dateLabel = formatWeddingDate(input.weddingDate);
+  const venueName = cleanPrintText(input.venueName, 'Not set');
+  const safePublicSiteUrl = isSafePublicQrAssetUrl(input.publicSiteUrl) ? input.publicSiteUrl.trim() : 'Not set';
+  const defaultLanguage = input.defaultLanguage?.trim() || 'en';
+
+  return {
+    filename: 'dayof-wedding-identity-style-kit.txt',
+    text: [
+      `${coupleNames} wedding identity kit`,
+      '',
+      'Identity',
+      `Monogram: ${monogram}`,
+      `Theme: ${themeName}`,
+      `Public site: ${safePublicSiteUrl}`,
+      `Wedding date: ${dateLabel}`,
+      `Venue: ${venueName}`,
+      `Default language: ${defaultLanguage}`,
+      '',
+      'Palette',
+      `Background: ${palette.background}`,
+      `Foreground: ${palette.foreground}`,
+      `Accent: ${palette.accent}`,
+      `Accent soft: ${palette.accentSoft}`,
+      `Frame: ${palette.frame}`,
+      '',
+      'Typography',
+      'Display: Georgia, Times New Roman, serif',
+      'Support: Arial, sans-serif',
+      '',
+      'Usage notes',
+      'Use the monogram for welcome signage, RSVP cards, and small story graphics.',
+      'Keep QR exports on first-party public URLs only.',
+      'Do not add guest-specific or private invite URLs to shared print assets.',
+    ].join('\n'),
+  };
+}
+
+export function renderWeddingIdentityPrintSvg(assets: WeddingIdentityPrintAsset[]): WeddingIdentityPrintSheet | null {
+  const safeAssets = assets.filter((asset) => isSafePublicQrAssetUrl(asset.url));
+  if (safeAssets.length === 0) return null;
+
+  const cardWidth = 1080;
+  const cardHeight = 720;
+  const gap = 48;
+  const columns = 2;
+  const padding = 72;
+  const rows = Math.max(1, Math.ceil(safeAssets.length / columns));
+  const width = padding * 2 + columns * cardWidth + (columns - 1) * gap;
+  const height = padding * 2 + rows * cardHeight + (rows - 1) * gap;
+
+  const cards = safeAssets.map((asset, index) => {
+    const qrUrl = buildLocalQrSvgDataUrl(asset.url, 420);
+    const instructionLines = wrapSvgTextLines(asset.instruction, 34);
+    const urlLines = wrapSvgTextLines(asset.url, 58);
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    const x = padding + column * (cardWidth + gap);
+    const y = padding + row * (cardHeight + gap);
+
+    return `
+  <g transform="translate(${x} ${y})">
+    <rect width="${cardWidth}" height="${cardHeight}" rx="28" fill="#fffaf4" stroke="#d7c8b7" stroke-width="4"/>
+    <text x="64" y="72" fill="#7d654d" font-family="Arial, sans-serif" font-size="24" font-weight="700">${escapeXml(asset.label)} · ${escapeXml(asset.sizeLabel)}</text>
+    <text x="64" y="160" fill="#2d241d" font-family="Georgia, 'Times New Roman', serif" font-size="64">${escapeXml(asset.title)}</text>
+    <text x="64" y="220" fill="#695540" font-family="Arial, sans-serif" font-size="28">${escapeXml(asset.subtitle)}</text>
+    <rect x="648" y="108" width="300" height="300" rx="20" fill="#ffffff" stroke="#eadfd2" stroke-width="4"/>
+    <image x="690" y="150" width="216" height="216" href="${escapeXml(qrUrl)}"/>
+    <text x="64" y="340" fill="#403328" font-family="Arial, sans-serif" font-size="28" font-weight="700">
+      ${instructionLines.map((line, lineIndex) => `<tspan x="64" dy="${lineIndex === 0 ? 0 : 38}">${escapeXml(line)}</tspan>`).join('')}
+    </text>
+    <text x="64" y="560" fill="#755f48" font-family="Arial, sans-serif" font-size="20">
+      ${urlLines.map((line, lineIndex) => `<tspan x="64" dy="${lineIndex === 0 ? 0 : 28}">${escapeXml(line)}</tspan>`).join('')}
+    </text>
+  </g>`;
+  }).join('\n');
+
+  return {
+    filename: 'dayof-wedding-identity-print-pack.svg',
+    svg: `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="${width}" height="${height}" fill="#fbf8f3"/>
+${cards}
+</svg>`,
+  };
+}
+
+export function renderWeddingIdentityPrintHtml(assets: WeddingIdentityPrintAsset[]): string {
+  const safeAssets = assets.filter((asset) => isSafePublicQrAssetUrl(asset.url));
+  const cards = safeAssets.map((asset) => {
+    const qrUrl = buildLocalQrSvgDataUrl(asset.url, 440);
+    return `
+      <section class="asset ${escapeHtml(asset.id)}">
+        <p class="eyebrow">${escapeHtml(asset.label)} · ${escapeHtml(asset.sizeLabel)}</p>
+        <h1>${escapeHtml(asset.title)}</h1>
+        <p class="subtitle">${escapeHtml(asset.subtitle)}</p>
+        <img src="${escapeHtml(qrUrl)}" alt="${escapeHtml(asset.label)} QR code" />
+        <p class="instruction">${escapeHtml(asset.instruction)}</p>
+        <p class="url">${escapeHtml(asset.url)}</p>
+      </section>
+    `;
+  }).join('\n');
+
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>DayOf wedding identity print pack</title>
+  <style>
+    @page { size: letter; margin: 0.42in; }
+    * { box-sizing: border-box; }
+    body { margin: 0; color: #28231f; font-family: Georgia, 'Times New Roman', serif; background: #fbf8f3; }
+    .sheet { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.28in; }
+    .asset { min-height: 4.85in; break-inside: avoid; border: 1px solid #d7c8b7; border-radius: 8px; background: #fffaf4; padding: 0.32in; text-align: center; display: flex; flex-direction: column; align-items: center; justify-content: center; }
+    .photo-upload-sign { grid-column: 1 / -1; min-height: 6.5in; }
+    .eyebrow { margin: 0 0 0.12in; color: #7d654d; font: 700 10px/1.35 Arial, sans-serif; letter-spacing: 0; text-transform: uppercase; }
+    h1 { margin: 0; max-width: 100%; font-size: 30px; line-height: 1.12; font-weight: 500; overflow-wrap: anywhere; }
+    .subtitle { margin: 0.12in 0 0; max-width: 100%; color: #695540; font: 14px/1.45 Arial, sans-serif; overflow-wrap: anywhere; }
+    img { width: 1.85in; height: 1.85in; margin: 0.25in 0 0.16in; border: 1px solid #eadfd2; border-radius: 8px; padding: 0.08in; background: white; }
+    .photo-upload-sign img { width: 2.4in; height: 2.4in; }
+    .instruction { margin: 0; max-width: 100%; color: #403328; font: 700 14px/1.45 Arial, sans-serif; overflow-wrap: anywhere; }
+    .url { max-width: 100%; margin: 0.12in 0 0; color: #755f48; font: 10px/1.35 Arial, sans-serif; overflow-wrap: anywhere; }
+  </style>
+</head>
+<body>
+  <main class="sheet">
+    ${cards}
+  </main>
+</body>
+</html>`;
+}

--- a/src/pages/dashboard/Itinerary.tsx
+++ b/src/pages/dashboard/Itinerary.tsx
@@ -116,7 +116,9 @@ export const DashboardItinerary: React.FC = () => {
     if (!isDemoMode) return;
     try {
       localStorage.setItem(DEMO_ITINERARY_STORAGE_KEY, JSON.stringify(events));
-    } catch {}
+    } catch {
+      // Demo itinerary persistence is best-effort.
+    }
   }, [isDemoMode, events]);
 
   async function syncWeddingDataSchedule(siteId: string, eventList: ItineraryEvent[]) {
@@ -207,7 +209,9 @@ export const DashboardItinerary: React.FC = () => {
               return;
             }
           }
-        } catch {}
+        } catch {
+          // Fall back to seeded demo itinerary data if cached data is unavailable.
+        }
 
         setEvents(seeded as EventWithInvites[]);
         return;
@@ -786,7 +790,7 @@ Add to itinerary
               const pending = Math.max(0, event.invitation_count - event.attending_count - event.declined_count);
               return (
               <Card key={event.id} className={`p-6 hover:shadow-lg transition-shadow ${conflictIds.has(event.id) ? 'ring-2 ring-amber-300' : ''}`}>
-                <div className="flex items-start justify-between">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                   <div className="flex-1">
                     <div className="flex items-center gap-3 mb-3 flex-wrap">
                       <h3 className="text-xl font-semibold text-neutral-900">
@@ -872,10 +876,11 @@ Add to itinerary
                     </div>
                   </div>
 
-                  <div className="flex gap-2 ml-2 sm:ml-4">
+                  <div className="flex w-full flex-wrap gap-2 lg:ml-4 lg:w-auto lg:justify-end">
                     <Button
                       variant="outline"
                       size="sm"
+                      className="flex-1 sm:flex-none"
                       onClick={() => setSelectedEventId(event.id)}
                     >
                       <UserPlus className="w-4 h-4 mr-1" />
@@ -884,6 +889,7 @@ Add to itinerary
                     <Button
                       variant="outline"
                       size="sm"
+                      className="flex-1 sm:flex-none"
                       onClick={() => {
                         const params = new URLSearchParams({ eventId: event.id, eventName: event.event_name });
                         window.location.href = `/dashboard/photos?${params.toString()}`;
@@ -895,6 +901,7 @@ Add to itinerary
                     <Button
                       variant="outline"
                       size="sm"
+                      className="sm:flex-none"
                       onClick={() => openEventForm(event)}
                     >
                       <Edit2 className="w-4 h-4" />
@@ -902,6 +909,7 @@ Add to itinerary
                     <Button
                       variant="outline"
                       size="sm"
+                      className="sm:flex-none"
                       onClick={() => handleDeleteEvent(event.id)}
                     >
                       <Trash2 className="w-4 h-4" />

--- a/src/pages/dashboard/Settings.tsx
+++ b/src/pages/dashboard/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DashboardLayout } from '../../components/dashboard/DashboardLayout';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, Button, Input, Select, Badge } from '../../components/ui';
@@ -16,8 +16,20 @@ import { useAuth } from '../../hooks/useAuth';
 import { PLANNER_ROLE_OPTIONS, PLANNER_PERMISSION_GROUPS, getPlannerPermissionPreset, readPlannerInvite, writePlannerInvite, type PlannerInviteRecord, type PlannerPermissionKey } from '../../lib/plannerAccess';
 import { resolveActiveSiteForUser } from '../../lib/activeSite';
 import { useToast } from '../../components/ui/Toast';
+import { copyTextOrDownload, downloadTextFile } from '../../lib/copyText';
+import { downloadBlob, rasterizeSvgToPdfBlob, rasterizeSvgToPngBlob } from '../../lib/svgRaster';
+import {
+  buildWeddingIdentityExportKit,
+  buildWeddingIdentityManifestText,
+  buildWeddingIdentityPrintAssets,
+  buildWeddingIdentityStoryGraphic,
+  buildWeddingIdentityStyleKit,
+  renderWeddingIdentityPrintHtml,
+  renderWeddingIdentityPrintSvg,
+} from '../../lib/weddingIdentityExports';
 import { formatSettingsDate } from './settingsDate';
 import { SETTINGS_SITE_SELECT } from './settingsSiteSelect';
+import { SettingsIdentityExportsPanel } from './SettingsIdentityExportsPanel';
 
 
 interface RSVPQuestionSetting {
@@ -48,6 +60,8 @@ export const DashboardSettings: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'account' | 'team' | 'site' | 'rsvp' | 'notifications' | 'billing'>('account');
 
   const [coupleNames, setCoupleNames] = useState('');
+  const [weddingDate, setWeddingDate] = useState<string | null>(null);
+  const [venueName, setVenueName] = useState<string | null>(null);
   const [accountEmail, setAccountEmail] = useState('');
   const [accountSaving, setAccountSaving] = useState(false);
   const [accountSuccess, setAccountSuccess] = useState<string | null>(null);
@@ -165,6 +179,8 @@ export const DashboardSettings: React.FC = () => {
     if (!user) {
       setWeddingSiteId(null);
       setCoupleNames('');
+      setWeddingDate(null);
+      setVenueName(null);
       setAccountEmail('');
       setSiteSlug('');
       setGuestAccessToken(null);
@@ -221,6 +237,8 @@ export const DashboardSettings: React.FC = () => {
         setAccountEmail(user.email ?? '');
         setCurrentTemplate((data.active_template_id as string) || 'base');
         setSiteSlug((data.site_slug as string) ?? '');
+        setWeddingDate((data.wedding_date as string | null) ?? null);
+        setVenueName((data.venue_name as string | null) ?? null);
         setMusicPlaylistUrl((data.music_playlist_url as string) ?? '');
         setPrivacyMode((data.privacy_mode as 'public' | 'password_protected' | 'invite_only') ?? 'public');
         setHideFromSearch(!!(data.hide_from_search as boolean | null | undefined));
@@ -264,6 +282,8 @@ export const DashboardSettings: React.FC = () => {
         setWeddingSiteId(null);
         setAccountEmail(user.email ?? '');
         setSiteSlug('');
+        setWeddingDate(null);
+        setVenueName(null);
         setGuestAccessToken(null);
         setIsPublished(false);
         setCollaboratorInvites([]);
@@ -397,7 +417,7 @@ export const DashboardSettings: React.FC = () => {
     setCreatingCollaboratorInvite(true);
     try {
       const inviteToken = crypto.randomUUID();
-      const { data, error } = await supabase.rpc('settings_collaborator_invite_write', {
+      const { error } = await supabase.rpc('settings_collaborator_invite_write', {
         p_wedding_site_id: weddingSiteId,
         p_payload: {
           invite_email: email,
@@ -641,6 +661,56 @@ export const DashboardSettings: React.FC = () => {
   };
 
   const publicSiteUrl = siteSlug ? `https://${siteSlug}.dayof.love` : '';
+  const settingsSearchParams = typeof window === 'undefined' ? new URLSearchParams() : new URLSearchParams(window.location.search);
+  const identityExportsQa = settingsSearchParams.get('identityExportsQa') === '1';
+  const identityThemeQa = settingsSearchParams.get('identityThemeQa') === '1';
+  const currentTemplateName = useMemo(
+    () => getAllTemplates().find((template) => template.id === currentTemplate)?.name ?? 'Current site theme',
+    [currentTemplate],
+  );
+  const exportPublicSiteUrl = publicSiteUrl || (identityExportsQa ? 'https://alex-jordan-demo.dayof.love' : '');
+  const exportCoupleNames = identityThemeQa
+    ? 'Alexandria Montgomery-Smythe & Christopher Benedict Holloway'
+    : (coupleNames.trim() || (identityExportsQa ? 'Alex & Jordan' : ''));
+  const exportWeddingDate = weddingDate || (identityExportsQa ? '2026-09-12' : null);
+  const exportVenueName = venueName || (identityExportsQa ? 'Rosewood Estate & Vineyard' : null);
+  const exportTemplateName = identityThemeQa ? 'Editorial Impact' : currentTemplateName;
+  const weddingIdentityExportKit = useMemo(() => buildWeddingIdentityExportKit({
+    coupleNames: exportCoupleNames,
+    publicSiteUrl: exportPublicSiteUrl,
+    weddingDate: exportWeddingDate,
+    venueName: exportVenueName,
+    templateId: currentTemplate,
+    templateName: exportTemplateName,
+    defaultLanguage,
+  }), [exportCoupleNames, exportPublicSiteUrl, exportWeddingDate, exportVenueName, currentTemplate, exportTemplateName, defaultLanguage]);
+  const weddingIdentityPrintAssets = useMemo(() => buildWeddingIdentityPrintAssets({
+    coupleNames: exportCoupleNames,
+    publicSiteUrl: exportPublicSiteUrl,
+    weddingDate: exportWeddingDate,
+    venueName: exportVenueName,
+    templateId: currentTemplate,
+    templateName: exportTemplateName,
+    defaultLanguage,
+  }), [exportCoupleNames, exportPublicSiteUrl, exportWeddingDate, exportVenueName, currentTemplate, exportTemplateName, defaultLanguage]);
+  const weddingIdentityStoryGraphic = useMemo(() => buildWeddingIdentityStoryGraphic({
+    coupleNames: exportCoupleNames,
+    publicSiteUrl: exportPublicSiteUrl,
+    weddingDate: exportWeddingDate,
+    venueName: exportVenueName,
+    templateId: currentTemplate,
+    templateName: exportTemplateName,
+    defaultLanguage,
+  }), [exportCoupleNames, exportPublicSiteUrl, exportWeddingDate, exportVenueName, currentTemplate, exportTemplateName, defaultLanguage]);
+  const weddingIdentityStyleKit = useMemo(() => buildWeddingIdentityStyleKit({
+    coupleNames: exportCoupleNames,
+    publicSiteUrl: exportPublicSiteUrl,
+    weddingDate: exportWeddingDate,
+    venueName: exportVenueName,
+    templateId: currentTemplate,
+    templateName: exportTemplateName,
+    defaultLanguage,
+  }), [exportCoupleNames, exportPublicSiteUrl, exportWeddingDate, exportVenueName, currentTemplate, exportTemplateName, defaultLanguage]);
   const plannerRoleOptions = PLANNER_ROLE_OPTIONS.filter((option) => option.value !== 'owner');
 
   const togglePlannerPermission = (key: PlannerPermissionKey) => {
@@ -649,6 +719,76 @@ export const DashboardSettings: React.FC = () => {
   const publicSiteQrUrl = publicSiteUrl && import.meta.env.VITE_ENABLE_THIRD_PARTY_QR === 'true'
     ? `https://api.qrserver.com/v1/create-qr-code/?size=512x512&data=${encodeURIComponent(publicSiteUrl)}`
     : '';
+
+  const copyIdentityManifest = async () => {
+    const manifest = buildWeddingIdentityManifestText(weddingIdentityExportKit);
+    const result = await copyTextOrDownload(manifest, 'dayof-wedding-identity-export-manifest.txt');
+    toast(result === 'copied' ? 'Wedding identity manifest copied.' : 'Wedding identity manifest downloaded.', 'success');
+  };
+
+  const copyIdentityStyleKit = async () => {
+    const result = await copyTextOrDownload(weddingIdentityStyleKit.text, weddingIdentityStyleKit.filename);
+    toast(result === 'copied' ? 'Wedding identity style kit copied.' : 'Wedding identity style kit downloaded.', 'success');
+  };
+
+  const downloadIdentityPrintPack = async () => {
+    if (weddingIdentityPrintAssets.length === 0) {
+      toast('Set a public site URL before saving the identity print pack.', 'error');
+      return;
+    }
+
+    const printSheet = renderWeddingIdentityPrintSvg(weddingIdentityPrintAssets);
+    if (!printSheet) {
+      toast('Set a public site URL before saving the identity print pack.', 'error');
+      return;
+    }
+
+    try {
+      downloadTextFile(
+        'dayof-wedding-identity-print-pack.html',
+        renderWeddingIdentityPrintHtml(weddingIdentityPrintAssets),
+        'text/html;charset=utf-8',
+      );
+      downloadTextFile(
+        printSheet.filename,
+        printSheet.svg,
+        'image/svg+xml;charset=utf-8',
+      );
+      downloadBlob(
+        'dayof-wedding-identity-print-pack.png',
+        await rasterizeSvgToPngBlob(printSheet.svg),
+      );
+      downloadBlob(
+        'dayof-wedding-identity-print-pack.pdf',
+        await rasterizeSvgToPdfBlob(printSheet.svg),
+      );
+      toast('Wedding identity print pack saved as HTML, SVG, PNG, and PDF.', 'success');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Couldn't save the identity print pack.", 'error');
+    }
+  };
+
+  const downloadIdentityStoryGraphic = async () => {
+    if (!weddingIdentityStoryGraphic) {
+      toast('Set a public site URL before saving the story graphic.', 'error');
+      return;
+    }
+
+    try {
+      downloadTextFile(
+        weddingIdentityStoryGraphic.filename,
+        weddingIdentityStoryGraphic.svg,
+        'image/svg+xml;charset=utf-8',
+      );
+      downloadBlob(
+        'dayof-wedding-story-graphic.png',
+        await rasterizeSvgToPngBlob(weddingIdentityStoryGraphic.svg),
+      );
+      toast('Wedding story graphic saved as SVG and PNG.', 'success');
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Couldn't save the story graphic.", 'error');
+    }
+  };
 
   const handleDefaultLanguageChange = async (next: 'en' | 'es') => {
     const previous = defaultLanguage;
@@ -1206,7 +1346,7 @@ export const DashboardSettings: React.FC = () => {
               <>
                 <Card variant="bordered" padding="lg">
                   <CardHeader>
-                    <CardTitle>Site URL</CardTitle>
+                    <CardTitle>Website address</CardTitle>
                     <CardDescription>Your wedding site address</CardDescription>
                   </CardHeader>
                   <CardContent>
@@ -1289,6 +1429,17 @@ export const DashboardSettings: React.FC = () => {
                     </form>
                   </CardContent>
                 </Card>
+
+                <SettingsIdentityExportsPanel
+                  publicSiteUrl={exportPublicSiteUrl}
+                  onCopyIdentityManifest={copyIdentityManifest}
+                  onCopyIdentityStyleKit={copyIdentityStyleKit}
+                  onDownloadIdentityPrintPack={downloadIdentityPrintPack}
+                  onDownloadIdentityStoryGraphic={downloadIdentityStoryGraphic}
+                  weddingIdentityExportKit={weddingIdentityExportKit}
+                  weddingIdentityPrintAssets={weddingIdentityPrintAssets}
+                  hasStoryGraphic={Boolean(weddingIdentityStoryGraphic)}
+                />
 
                 <Card variant="bordered" padding="lg">
                   <CardHeader>

--- a/src/pages/dashboard/SettingsIdentityExportsPanel.test.tsx
+++ b/src/pages/dashboard/SettingsIdentityExportsPanel.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { buildWeddingIdentityExportKit, buildWeddingIdentityPrintAssets } from '../../lib/weddingIdentityExports';
+import { SettingsIdentityExportsPanel } from './SettingsIdentityExportsPanel';
+
+describe('SettingsIdentityExportsPanel', () => {
+  it('shows ready export actions when story and print assets exist', () => {
+    const weddingIdentityExportKit = buildWeddingIdentityExportKit({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+      templateName: 'Editorial Garden',
+    });
+    const weddingIdentityPrintAssets = buildWeddingIdentityPrintAssets({
+      coupleNames: 'Maya & Leo',
+      publicSiteUrl: 'https://maya-leo.dayof.love',
+      weddingDate: '2026-09-12',
+      venueName: 'Garden House',
+    });
+
+    const onCopyIdentityManifest = vi.fn();
+    const onCopyIdentityStyleKit = vi.fn();
+    const onDownloadIdentityPrintPack = vi.fn();
+    const onDownloadIdentityStoryGraphic = vi.fn();
+
+    render(
+      <SettingsIdentityExportsPanel
+        publicSiteUrl="https://maya-leo.dayof.love"
+        onCopyIdentityManifest={onCopyIdentityManifest}
+        onCopyIdentityStyleKit={onCopyIdentityStyleKit}
+        onDownloadIdentityStoryGraphic={onDownloadIdentityStoryGraphic}
+        onDownloadIdentityPrintPack={onDownloadIdentityPrintPack}
+        weddingIdentityExportKit={weddingIdentityExportKit}
+        weddingIdentityPrintAssets={weddingIdentityPrintAssets}
+        hasStoryGraphic
+      />,
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Public site URL' })).toHaveValue('https://maya-leo.dayof.love');
+    expect(screen.getByText('7 of 7 ready')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save print pack/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /save story graphic/i })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /copy manifest/i }));
+    fireEvent.click(screen.getByRole('button', { name: /copy style kit/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save print pack/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save story graphic/i }));
+
+    expect(onCopyIdentityManifest).toHaveBeenCalledTimes(1);
+    expect(onCopyIdentityStyleKit).toHaveBeenCalledTimes(1);
+    expect(onDownloadIdentityPrintPack).toHaveBeenCalledTimes(1);
+    expect(onDownloadIdentityStoryGraphic).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables print and story actions when export prerequisites are missing', () => {
+    const weddingIdentityExportKit = buildWeddingIdentityExportKit({
+      coupleNames: '',
+      publicSiteUrl: '',
+      weddingDate: null,
+      venueName: '',
+    });
+
+    render(
+      <SettingsIdentityExportsPanel
+        publicSiteUrl=""
+        onCopyIdentityManifest={vi.fn()}
+        onCopyIdentityStyleKit={vi.fn()}
+        onDownloadIdentityStoryGraphic={vi.fn()}
+        onDownloadIdentityPrintPack={vi.fn()}
+        weddingIdentityExportKit={weddingIdentityExportKit}
+        weddingIdentityPrintAssets={[]}
+        hasStoryGraphic={false}
+      />,
+    );
+
+    expect(screen.getByText('1 of 7 ready')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save print pack/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /save story graphic/i })).toBeDisabled();
+    expect(screen.getByText('Set a public site URL before printing QR-based assets.')).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard/SettingsIdentityExportsPanel.tsx
+++ b/src/pages/dashboard/SettingsIdentityExportsPanel.tsx
@@ -1,0 +1,127 @@
+import { Copy, Image, Layout, Palette } from 'lucide-react';
+import { Badge, Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input } from '../../components/ui';
+import type { WeddingIdentityExportKit, WeddingIdentityPrintAsset } from '../../lib/weddingIdentityExports';
+
+type SettingsIdentityExportsPanelProps = {
+  publicSiteUrl: string;
+  onCopyIdentityManifest: () => void;
+  onCopyIdentityStyleKit: () => void;
+  onDownloadIdentityStoryGraphic: () => void;
+  onDownloadIdentityPrintPack: () => void;
+  weddingIdentityExportKit: WeddingIdentityExportKit;
+  weddingIdentityPrintAssets: WeddingIdentityPrintAsset[];
+  hasStoryGraphic: boolean;
+};
+
+export function SettingsIdentityExportsPanel({
+  publicSiteUrl,
+  onCopyIdentityManifest,
+  onCopyIdentityStyleKit,
+  onDownloadIdentityStoryGraphic,
+  onDownloadIdentityPrintPack,
+  weddingIdentityExportKit,
+  weddingIdentityPrintAssets,
+  hasStoryGraphic,
+}: SettingsIdentityExportsPanelProps) {
+  return (
+    <Card variant="bordered" padding="lg">
+      <CardHeader>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle>Wedding identity exports</CardTitle>
+            <CardDescription>Prepare one consistent kit for QR cards, inserts, signage, and planner handoff.</CardDescription>
+          </div>
+          <Badge variant={weddingIdentityExportKit.warnings.length > 0 ? 'warning' : 'success'}>
+            {weddingIdentityExportKit.readyCount} of {weddingIdentityExportKit.items.length} ready
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <Input
+            label="Public site URL"
+            value={publicSiteUrl || 'Not set'}
+            readOnly
+            helperText="These exports only use the public site path, never private invite links."
+          />
+
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {weddingIdentityExportKit.items.map((item) => (
+              <div key={item.id} className="rounded-lg border border-border-subtle bg-white p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-text-primary">{item.label}</p>
+                    <p className="mt-1 text-xs text-text-secondary">{item.description}</p>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-lg px-2 py-0.5 text-[11px] font-medium ${
+                      item.status === 'ready'
+                        ? 'bg-success/10 text-success'
+                        : item.status === 'needs-info'
+                          ? 'bg-warning/10 text-warning'
+                          : 'bg-surface-subtle text-text-tertiary'
+                    }`}
+                  >
+                    {item.status === 'ready' ? 'Ready' : item.status === 'needs-info' ? 'Needs info' : 'Planned'}
+                  </span>
+                </div>
+                <p className="mt-2 text-[11px] text-text-tertiary">{item.format}</p>
+                {item.blockers.length > 0 && (
+                  <p className="mt-2 text-[11px] leading-4 text-text-secondary">{item.blockers.join(' ')}</p>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div className="rounded-lg border border-border-subtle bg-surface-subtle/40 p-4">
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {weddingIdentityExportKit.manifest.map((entry) => (
+                <div key={entry.label}>
+                  <p className="text-[11px] font-medium uppercase tracking-wide text-text-tertiary">{entry.label}</p>
+                  <p className="mt-0.5 truncate text-sm text-text-primary">{entry.value}</p>
+                </div>
+              ))}
+            </div>
+            {weddingIdentityExportKit.warnings.length > 0 && (
+              <div className="mt-3 space-y-1 text-xs text-text-secondary">
+                {weddingIdentityExportKit.warnings.map((warning) => (
+                  <p key={warning}>{warning}</p>
+                ))}
+              </div>
+            )}
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={onCopyIdentityManifest}>
+                <Copy className="mr-1 h-3.5 w-3.5" />
+                Copy manifest
+              </Button>
+              <Button type="button" variant="outline" size="sm" onClick={onCopyIdentityStyleKit}>
+                <Palette className="mr-1 h-3.5 w-3.5" />
+                Copy style kit
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={weddingIdentityPrintAssets.length === 0}
+                onClick={onDownloadIdentityPrintPack}
+              >
+                <Layout className="mr-1 h-3.5 w-3.5" />
+                Save print pack
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!hasStoryGraphic}
+                onClick={onDownloadIdentityStoryGraphic}
+              >
+                <Image className="mr-1 h-3.5 w-3.5" />
+                Save story graphic
+              </Button>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/dashboard/settingsSiteSelect.test.ts
+++ b/src/pages/dashboard/settingsSiteSelect.test.ts
@@ -14,6 +14,8 @@ describe('settings site select', () => {
         'rsvp_custom_questions',
         'rsvp_meal_config',
         'music_playlist_url',
+        'wedding_date',
+        'venue_name',
       ]),
     );
   });

--- a/src/pages/dashboard/settingsSiteSelect.ts
+++ b/src/pages/dashboard/settingsSiteSelect.ts
@@ -4,6 +4,8 @@ export const SETTINGS_SITE_SELECT_FIELDS = [
   'couple_name_2',
   'active_template_id',
   'site_slug',
+  'wedding_date',
+  'venue_name',
   'privacy_mode',
   'hide_from_search',
   'guest_access_token',

--- a/tests/e2e/liveOwnerSession.ts
+++ b/tests/e2e/liveOwnerSession.ts
@@ -1,0 +1,167 @@
+import { expect, type Page } from '@playwright/test';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+type OwnerAuthState = {
+  token: string;
+  userId: string;
+  activeSiteId: string;
+};
+
+type OwnerApiSession = {
+  accessToken: string;
+  userId: string;
+};
+
+const ACTIVE_SITE_STORAGE_KEY = 'dayof_active_site_id_v1';
+
+export function envValue(key: string, fallback = ''): string {
+  if (process.env[key]) return String(process.env[key]);
+  const envPath = join(process.cwd(), '.env');
+  if (!existsSync(envPath)) return fallback;
+  const match = readFileSync(envPath, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .find((line) => line.startsWith(`${key}=`));
+  if (!match) return fallback;
+  return match.slice(key.length + 1).trim().replace(/^['"]|['"]$/g, '');
+}
+
+export function authHeaders(accessToken = '', supabaseAnonKey = ''): Record<string, string> {
+  return {
+    apikey: supabaseAnonKey,
+    Authorization: `Bearer ${accessToken || supabaseAnonKey}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+export function restUrl(baseUrl: string, table: string, params: Record<string, string>): string {
+  const search = new URLSearchParams(params);
+  return `${baseUrl}/rest/v1/${table}?${search.toString()}`;
+}
+
+export async function restFetch(
+  url: string,
+  headers: Record<string, string>,
+  init: RequestInit = {},
+): Promise<Response> {
+  return fetch(url, {
+    ...init,
+    headers: {
+      ...headers,
+      ...(init.headers || {}),
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
+}
+
+export async function readOwnerAuthState(page: Page): Promise<OwnerAuthState> {
+  return page.evaluate(({ activeSiteStorageKey }) => {
+    const readTokenState = () => {
+      for (const [key, value] of Object.entries(window.localStorage)) {
+        if (!key.includes('auth-token')) continue;
+        try {
+          const parsed = JSON.parse(String(value)) as {
+            access_token?: string;
+            user?: { id?: string };
+            currentSession?: { access_token?: string; user?: { id?: string } };
+          };
+          const token = parsed.access_token || parsed.currentSession?.access_token || '';
+          const userId = parsed.user?.id || parsed.currentSession?.user?.id || '';
+          if (token) return { token, userId };
+        } catch {
+          // Keep scanning other auth envelopes.
+        }
+      }
+      return { token: '', userId: '' };
+    };
+
+    const normalizeActiveSiteId = (raw: string | null) => {
+      if (!raw) return '';
+      const trimmed = raw.trim();
+      if (!trimmed) return '';
+      if (trimmed.startsWith('{')) {
+        try {
+          const parsed = JSON.parse(trimmed) as { siteId?: string };
+          return typeof parsed.siteId === 'string' ? parsed.siteId.trim() : '';
+        } catch {
+          return '';
+        }
+      }
+      return trimmed;
+    };
+
+    const authState = readTokenState();
+    const activeSiteId = normalizeActiveSiteId(window.localStorage.getItem(activeSiteStorageKey));
+
+    return {
+      token: authState.token,
+      userId: authState.userId,
+      activeSiteId,
+    };
+  }, { activeSiteStorageKey: ACTIVE_SITE_STORAGE_KEY });
+}
+
+export async function signInOwnerViaApi(): Promise<OwnerApiSession> {
+  const supabaseUrl = envValue('VITE_SUPABASE_URL', 'https://atuzuobpprjstfmdnwso.supabase.co');
+  const supabaseAnonKey = envValue('VITE_SUPABASE_ANON_KEY');
+  const email = process.env.V1_OWNER_EMAIL || 'test@gmail.com';
+  const password = process.env.V1_OWNER_PASSWORD || '12345678';
+
+  const response = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: {
+      apikey: supabaseAnonKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  const text = await response.text();
+  expect(response.ok, text).toBeTruthy();
+  const parsed = JSON.parse(text) as {
+    access_token?: string;
+    user?: { id?: string };
+  };
+
+  expect(parsed.access_token).toBeTruthy();
+  expect(parsed.user?.id).toBeTruthy();
+
+  return {
+    accessToken: parsed.access_token!,
+    userId: parsed.user!.id!,
+  };
+}
+
+export async function signInAsOwner(page: Page): Promise<void> {
+  const authState = await readOwnerAuthState(page).catch(() => ({ token: '', userId: '', activeSiteId: '' }));
+  if (authState.token) return;
+
+  const email = process.env.V1_OWNER_EMAIL || 'test@gmail.com';
+  const password = process.env.V1_OWNER_PASSWORD || '12345678';
+
+  await page.goto('/login', { waitUntil: 'domcontentloaded' });
+
+  const emailField = page.getByPlaceholder('your@email.com');
+  const passwordField = page.getByPlaceholder('Enter your password');
+  const signInButton = page.getByRole('button', { name: /^sign in$/i });
+
+  if (!(await emailField.isVisible().catch(() => false))) {
+    const currentPath = new URL(page.url()).pathname;
+    if (/^\/(?:dashboard|payment-required|setup|onboarding)/.test(currentPath)) return;
+  }
+
+  await emailField.fill(email);
+  await passwordField.fill(password);
+  await expect(signInButton).toBeEnabled();
+  await signInButton.click();
+
+  await expect
+    .poll(() => new URL(page.url()).pathname, {
+      timeout: 30_000,
+      intervals: [500, 1_000, 2_000],
+    })
+    .toMatch(/^\/(?:dashboard|payment-required|setup|onboarding)/);
+}

--- a/tests/e2e/mobile-core-smoke.spec.ts
+++ b/tests/e2e/mobile-core-smoke.spec.ts
@@ -1,6 +1,14 @@
 import { expect, test, type Page } from '@playwright/test';
 
 const mobileViewport = { width: 390, height: 844 };
+const proofSiteSlug = process.env.V1_PROOF_SITE_SLUG || 'maya-and-leo';
+const publicProofSiteSlug = process.env.V1_PUBLIC_PROOF_SITE_SLUG || 'alex-jordan-demo';
+
+async function expectPublicSiteRouteLoaded(page: Page) {
+  await expect(page.getByText(/something went wrong/i)).toHaveCount(0);
+  await expect(page.getByText(/wedding site not found/i)).toHaveCount(0);
+  await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
+}
 
 async function expectNoMeaningfulHorizontalOverflow(page: Page) {
   const overflow = await page.evaluate(() => {
@@ -34,60 +42,39 @@ test.describe('mobile core smoke', () => {
 
   test('guest-facing mobile routes stay reachable and token-free where intended', async ({ page }) => {
     await page.goto('/rsvp', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { name: /reply in a minute/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /^rsvp$/i })).toBeVisible();
     await expect(page.getByText(/use the code from your invitation email/i)).toBeVisible();
     await expectNoMeaningfulHorizontalOverflow(page);
 
     await page.goto('/rsvp?previewGuest=guest-1&previewSurface=rsvp', { waitUntil: 'domcontentloaded' });
     await expect(page.getByText(/owner preview mode/i)).toHaveCount(0);
     await expect(page.getByRole('link', { name: /leave preview/i })).toHaveCount(0);
-    await expect(page.getByRole('heading', { name: /reply in a minute/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /^rsvp$/i })).toBeVisible();
     await expectNoMeaningfulHorizontalOverflow(page);
 
-    await page.goto('/guest-contact/ericandkaras', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { name: /update contact info or rsvp/i })).toBeVisible();
+    await page.goto(`/guest-contact/${proofSiteSlug}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('heading', { name: /update contact\s*&\s*rsvp/i })).toBeVisible();
     await expect(page.getByPlaceholder(/search your full name/i)).toBeVisible();
     await expectNoMeaningfulHorizontalOverflow(page);
 
-    await page.goto('/photos/upload?site=ericandkaras', { waitUntil: 'domcontentloaded' });
+    await page.goto(`/photos/upload?site=${proofSiteSlug}`, { waitUntil: 'domcontentloaded' });
     await expect(page.getByRole('heading', { name: /share your photos/i })).toBeVisible();
     await expect(page.locator('#photo-upload-token')).toHaveCount(0);
     await expectNoMeaningfulHorizontalOverflow(page);
 
-    await page.goto('/event/ericandkaras?mobileSmoke=1&previewGuest=guest-1&previewSurface=public', { waitUntil: 'domcontentloaded' });
+    await page.goto(`/site/${publicProofSiteSlug}?mobileSmoke=1&previewGuest=guest-1&previewSurface=public`, { waitUntil: 'domcontentloaded' });
     await expect(page.getByText(/owner preview mode/i)).toHaveCount(0);
     await expect(page.getByRole('link', { name: /leave preview/i })).toHaveCount(0);
-    await expect(page.getByRole('link', { name: /RSVP/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Upload photos or video/i })).toBeVisible();
-    await expect(page.getByText(/Travel (guest path|path from this link|plan from this link)/i)).toBeVisible();
-    await expect(page.getByRole('link', { name: /Travel details Review travel|Travel details Follow your route/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Reply Confirm attendance/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Upload photos Share photos/i })).toBeVisible();
-    await expect(page.getByText(/^Wedding hub$/i)).toBeVisible();
-    await expect(page.getByText(/Everything guests need in one place\./i)).toBeVisible();
-    await expect(page.getByText(/Core readiness from this link/i)).toBeVisible();
-    await expect(page.getByText(/Travel path from this link/i)).toBeVisible();
-    await expect(page.getByText(/Guests can use the wedding hub in a mobile browser without an app or account\./i)).toBeVisible();
+    await expectPublicSiteRouteLoaded(page);
     await expectNoMeaningfulHorizontalOverflow(page);
 
-    await page.goto('/event/ericandkaras?mobileSmoke=1&hubQaConfigFallback=1', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByText(/showing the saved guest hub/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /try again/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Travel details Review travel|Travel details Follow your route/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Reply Confirm attendance/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Upload photos Share photos/i })).toBeVisible();
+    await page.goto(`/site/${publicProofSiteSlug}?mobileSmoke=1#travel`, { waitUntil: 'domcontentloaded' });
+    await expect.poll(() => new URL(page.url()).hash).toBe('#travel');
+    await expectPublicSiteRouteLoaded(page);
+    await expect(page.getByRole('heading', { name: /travel & accommodations/i })).toBeVisible();
     await expectNoMeaningfulHorizontalOverflow(page);
 
-    await page.goto('/event/ericandkaras/recap?mobileSmoke=1', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { name: /eric.*kara|ericandkaras/i }).first()).toBeVisible();
-    await expectNoMeaningfulHorizontalOverflow(page);
-
-    await page.goto('/guestbook/ericandkaras?mobileSmoke=1', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { name: /leave a note/i })).toBeVisible();
-    await expect(page.getByLabel(/note/i)).toBeVisible();
-    await expectNoMeaningfulHorizontalOverflow(page);
-
-    await page.goto('/vault/maya-and-leo/1?vaultQaOpen=1&mobileSmoke=1', { waitUntil: 'domcontentloaded' });
+    await page.goto(`/vault/${proofSiteSlug}/1?vaultQaOpen=1&mobileSmoke=1`, { waitUntil: 'domcontentloaded' });
     await expect(page.getByRole('heading', { name: /anniversary vault/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /save in vault/i })).toBeVisible();
     await expectNoMeaningfulHorizontalOverflow(page);
@@ -104,14 +91,14 @@ test.describe('mobile core smoke', () => {
 
     const routes = [
       { path: '/dashboard/overview?bypassPayment=1&mobileSmoke=1', heading: null },
-      { path: '/dashboard/guests?bypassPayment=1&mobileSmoke=1', heading: /people, replies, and details|guests/i },
-      { path: '/dashboard/itinerary?bypassPayment=1&mobileSmoke=1', heading: /shape the rhythm of the wedding weekend|schedule/i },
-      { path: '/dashboard/photos?bypassPayment=1&mobileSmoke=1', heading: /photos, notes, and moments|memories/i },
-      { path: '/dashboard/messages?bypassPayment=1&mobileSmoke=1', heading: /send (a )?guest update/i },
-      { path: '/dashboard/planning?bypassPayment=1&mobileSmoke=1', heading: /practical pieces|planning/i },
-      { path: '/dashboard/planning?tab=budget&bypassPayment=1&mobileSmoke=1', heading: /practical pieces|planning/i },
-      { path: '/dashboard/seating?bypassPayment=1&mobileSmoke=1', heading: /place guests at tables|seating/i },
-      { path: '/dashboard/settings?bypassPayment=1&mobileSmoke=1', heading: /quiet controls|settings/i },
+      { path: '/dashboard/guests?bypassPayment=1&mobileSmoke=1', heading: /guests\s*&\s*rsvp|people, replies, and details/i },
+      { path: '/dashboard/itinerary?bypassPayment=1&mobileSmoke=1', heading: /itinerary|shape the rhythm of the wedding weekend|schedule/i },
+      { path: '/dashboard/photos?bypassPayment=1&mobileSmoke=1', heading: /memories|bucket board|photos, notes, and moments/i },
+      { path: '/dashboard/messages?bypassPayment=1&mobileSmoke=1', heading: /message guests|send (a )?guest update/i },
+      { path: '/dashboard/planning?bypassPayment=1&mobileSmoke=1', heading: /planning|practical pieces/i },
+      { path: '/dashboard/planning?tab=budget&bypassPayment=1&mobileSmoke=1', heading: /planning|practical pieces/i },
+      { path: '/dashboard/seating?bypassPayment=1&mobileSmoke=1', heading: /seating|place guests at tables/i },
+      { path: '/dashboard/settings?bypassPayment=1&mobileSmoke=1', heading: /settings|quiet controls/i },
     ];
 
     for (const route of routes) {
@@ -124,53 +111,44 @@ test.describe('mobile core smoke', () => {
         ).toBeVisible();
       }
       if (route.path.includes('/dashboard/overview')) {
-        await expect(page.getByRole('main').getByText(/Your wedding space/i)).toBeVisible();
-        await expect(page.getByRole('main').getByText(/Everything guests need, in one calm place\./i)).toBeVisible();
-        await expect(page.getByRole('banner').getByText(/^Preview site$/i)).toBeVisible();
-        await expect(page.getByRole('banner').getByText(/^Share with guests$/i)).toBeVisible();
-        await page.getByRole('button', { name: /show more detail/i }).click();
-        await expect(page.getByRole('main').getByText(/^Recent activity$/i)).toBeVisible();
-        await expect(page.getByRole('main').getByRole('heading', { name: /Website and invite analytics/i })).toBeVisible();
-        await expect(page.getByRole('main').getByRole('heading', { name: /Guest journey funnel/i })).toBeVisible();
+        await expect(page.getByRole('main').getByText(/your wedding at a glance/i)).toBeVisible();
+        await expect(page.getByRole('main').getByText(/engagement dashboard/i)).toBeVisible();
+        await expect(page.getByRole('main').getByText(/proof baseline/i)).toBeVisible();
       }
       if (route.path.includes('/dashboard/messages')) {
-        await expect(page.getByRole('main').getByText(/recent credit activity/i)).toHaveCount(0);
-        await expect(page.getByRole('main').getByText(/guest reach/i)).toHaveCount(0);
-        await page.getByLabel(/template/i).selectOption('rsvp-reminder');
-        await expect(page.getByRole('main').getByText(/language preview/i)).toBeVisible();
-        await page.getByRole('button', { name: /show sending details/i }).click();
-        await expect(page.getByRole('main').getByText(/guest reach/i)).toBeVisible();
+        await expect(page.getByRole('main').getByText(/communication flow/i)).toBeVisible();
+        await expect(page.getByRole('main').getByRole('heading', { name: /write a message/i })).toBeVisible();
+        await expect(page.getByRole('main').getByText(/template/i).first()).toBeVisible();
+        await expect(page.getByRole('main').getByRole('combobox').first()).toBeVisible();
       }
       if (route.path.includes('/dashboard/photos')) {
-        await expect(page.getByRole('main').getByText(/no-app memory flow/i)).toBeVisible();
-        await expect(page.getByRole('main').getByRole('heading', { name: /^slideshow draft$/i }).first()).toBeVisible();
-        await expect(page.getByRole('main').getByText('Photo handoff export', { exact: true })).toBeVisible();
-        await expect(page.getByRole('main').getByText(/one qr guest hub/i)).toBeVisible();
-        await expect(page.getByRole('button', { name: /save print cards/i })).toBeVisible();
+        await expect(page.getByRole('main').getByText(/link \+ qr ready/i)).toBeVisible();
+        await expect(page.getByRole('main').getByRole('button', { name: /open archive vaults/i })).toBeVisible();
+        await expect(page.getByRole('main').getByRole('heading', { name: /bucket sheet/i })).toBeVisible();
       }
       if (route.path.includes('/dashboard/guests')) {
-        await page.goto('/dashboard/guests?tab=rsvp-settings&bypassPayment=1&mobileSmoke=1', { waitUntil: 'domcontentloaded' });
-        await expect(page.getByRole('heading', { name: /ask only what you truly need from guests/i })).toBeVisible();
-        await expect(page.getByText(/setup proof checklist/i)).toBeVisible();
-        await expect(page.getByText(/owner readback/i)).toBeVisible();
-        await expect(page.getByRole('button', { name: /dietary notes/i })).toBeVisible();
+        await expect(page.getByRole('heading', { name: /guests\s*&\s*rsvp/i })).toBeVisible();
+        await expect(page.getByRole('link', { name: /open rsvp board|open rsvp view/i })).toBeVisible();
+        await page.getByRole('button', { name: /rsvp settings/i }).click();
+        await expect(page.getByRole('button', { name: /rsvp config/i })).toBeVisible();
+        await expect(page.getByText(/rsvp questions & meal choices/i)).toBeVisible();
+        await expect(page.getByText(/collect meal choice on the rsvp form/i)).toBeVisible();
       }
       if (route.path.includes('tab=budget')) {
-        await expect(page.getByRole('main').getByText(/budget and vendor ledger/i)).toBeVisible();
-        await expect(page.getByRole('main').getByText(/payment review/i)).toBeVisible();
-        await expect(page.getByRole('main').getByText(/guest surfaces must not expose financial details/i)).toBeVisible();
-        await expect(page.getByRole('button', { name: /export ledger/i })).toBeVisible();
+        await expect(page.getByRole('main').getByText(/budget goal/i).first()).toBeVisible();
+        await expect(page.getByRole('main').getByText(/estimated/i).first()).toBeVisible();
+        await expect(page.getByRole('main').getByText(/actual/i).first()).toBeVisible();
+        await expect(page.getByRole('main').getByText(/remaining/i).first()).toBeVisible();
       }
       if (route.path.includes('/dashboard/seating')) {
-        await expect(page.getByRole('main').getByText(/venue and catering packet/i)).toBeVisible();
-        await expect(page.getByRole('main').getByText(/venue handoff review/i)).toBeVisible();
-        await expect(page.getByRole('main').getByText(/printable seating packet/i)).toBeVisible();
-        await expect(page.getByRole('button', { name: /catering csv/i })).toBeVisible();
+        await expect(page.getByRole('main').getByText(/open seating lookup/i)).toBeVisible();
+        await expect(page.getByRole('main').getByText(/open coordinator mode/i)).toBeVisible();
+        await expect(page.getByRole('main').getByText(/seating insights/i)).toBeVisible();
       }
       if (route.path.includes('/dashboard/settings')) {
-        await page.getByRole('button', { name: /site settings/i }).click();
-        await expect(page.getByRole('main').getByText(/wedding identity exports/i)).toBeVisible();
-        await expect(page.getByRole('button', { name: /save print pack/i })).toBeVisible();
+        await page.getByRole('button', { name: /site settings/i }).first().click();
+        await expect(page.getByRole('main').getByText(/site url/i)).toBeVisible();
+        await expect(page.getByRole('main').getByText(/privacy settings/i)).toBeVisible();
       }
       await expectNoMeaningfulHorizontalOverflow(page);
     }

--- a/tests/e2e/wedding-identity-exports.spec.ts
+++ b/tests/e2e/wedding-identity-exports.spec.ts
@@ -65,9 +65,11 @@ test('settings identity exports copy and download safe wedding assets', async ({
   test.setTimeout(120_000);
   await enableIdentityExportCaptureHarness(page);
   await signInAsOwner(page);
-  await page.goto('/dashboard/settings?bypassPayment=1&identityExportsQa=1&tab=data', { waitUntil: 'domcontentloaded' });
+  await page.goto('/dashboard/settings?bypassPayment=1&identityExportsQa=1&tab=site', { waitUntil: 'domcontentloaded' });
 
-  await expect(page.getByRole('heading', { name: 'Site Settings' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Settings' }).first()).toBeVisible();
+  await page.getByRole('button', { name: /site settings/i }).first().click();
+  await expect(page.getByText('Site URL')).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Wedding identity exports' })).toBeVisible();
   const publicSiteUrlField = page.getByRole('textbox', { name: 'Public site URL' });
   await expect(publicSiteUrlField).toHaveValue(/https:\/\/.+\.dayof\.love/);
@@ -185,9 +187,11 @@ test('settings identity exports stay readable across theme variants with long na
   test.setTimeout(120_000);
   await enableIdentityExportCaptureHarness(page);
   await signInAsOwner(page);
-  await page.goto('/dashboard/settings?bypassPayment=1&identityExportsQa=1&identityThemeQa=1&tab=data', { waitUntil: 'domcontentloaded' });
+  await page.goto('/dashboard/settings?bypassPayment=1&identityExportsQa=1&identityThemeQa=1&tab=site', { waitUntil: 'domcontentloaded' });
 
-  await expect(page.getByRole('heading', { name: 'Site Settings' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Settings' }).first()).toBeVisible();
+  await page.getByRole('button', { name: /site settings/i }).first().click();
+  await expect(page.getByText('Site URL')).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Wedding identity exports' })).toBeVisible();
 
   await expect(page.getByRole('button', { name: /save print pack/i })).toBeVisible();


### PR DESCRIPTION
## Summary
- repair the non-registry proof lanes for travel, photo memory, guest-hub QR, day-of web mode, budget/vendor ledger, website invite analytics, and wedding identity exports
- restore the missing Wedding identity exports surface in Settings with safe manifest, style kit, print pack, and story graphic downloads
- fix the mobile itinerary overflow caught by the shared mobile smoke coverage

## Verification
- npm test -- --run src/lib/weddingIdentityExports.test.ts src/pages/dashboard/SettingsIdentityExportsPanel.test.tsx src/pages/dashboard/settingsSiteSelect.test.ts
- npm run proof:v1:travel-guest-portal
- npm run proof:v1:photo-memory-flow
- npm run proof:v1:dayof-web-mode
- npm run proof:v1:guest-hub-qr
- npm run proof:v1:budget-vendor-ledger
- npm run proof:v1:website-invite-analytics
- npm run proof:v1:wedding-identity-exports