### PR TITLE
Add guest ops coach to dashboard flows

### DIFF
--- a/src/lib/guestOpsCoach.test.ts
+++ b/src/lib/guestOpsCoach.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { buildGuestOpsCoach, buildMessageOpsCoach } from './guestOpsCoach';
+
+describe('buildGuestOpsCoach', () => {
+  it('prioritizes missing pending email before reminder work', () => {
+    const coach = buildGuestOpsCoach({
+      totalGuests: 48,
+      attendingGuests: 20,
+      pendingResponses: 12,
+      pendingWithoutEmail: 4,
+      noContact: 6,
+      missingMealChoices: 3,
+      missingPlusOneNames: 1,
+      manualFollowUp: 2,
+    });
+
+    expect(coach.primaryAction?.id).toBe('collect-pending-email');
+    expect(coach.tone).toBe('urgent');
+    expect(coach.actions.map((action) => action.id)).toContain('send-rsvp-reminder');
+  });
+
+  it('falls back to a healthy summary when the lane is calm', () => {
+    const coach = buildGuestOpsCoach({
+      totalGuests: 32,
+      attendingGuests: 18,
+      pendingResponses: 0,
+      pendingWithoutEmail: 0,
+      noContact: 0,
+      missingMealChoices: 0,
+      missingPlusOneNames: 0,
+      manualFollowUp: 0,
+    });
+
+    expect(coach.primaryAction?.id).toBe('healthy');
+    expect(coach.statusLabel).toBe('Healthy');
+    expect(coach.summary).toMatch(/looks steady/i);
+  });
+});
+
+describe('buildMessageOpsCoach', () => {
+  it('prioritizes review work before new sends', () => {
+    const coach = buildMessageOpsCoach(
+      {
+        totalGuests: 48,
+        attendingGuests: 22,
+        pendingResponses: 10,
+        pendingWithoutEmail: 0,
+        noContact: 0,
+        missingMealChoices: 0,
+        missingPlusOneNames: 0,
+      },
+      {
+        scheduledCount: 1,
+        overdueScheduledCount: 0,
+        partialCount: 2,
+        failedCount: 1,
+        unreachedRecipientCount: 6,
+      },
+    );
+
+    expect(coach.plays[0]?.id).toBe('review-partial');
+    expect(coach.plays[1]?.id).toBe('review-failed');
+  });
+
+  it('suggests a reminder when review queues are clear', () => {
+    const coach = buildMessageOpsCoach(
+      {
+        totalGuests: 48,
+        attendingGuests: 22,
+        pendingResponses: 10,
+        pendingWithoutEmail: 0,
+        noContact: 0,
+        missingMealChoices: 0,
+        missingPlusOneNames: 0,
+      },
+      {
+        scheduledCount: 0,
+        overdueScheduledCount: 0,
+        partialCount: 0,
+        failedCount: 0,
+        unreachedRecipientCount: 0,
+      },
+    );
+
+    expect(coach.plays[0]?.id).toBe('send-rsvp-reminder');
+    expect(coach.plays.map((play) => play.id)).toContain('stage-day-of-update');
+  });
+});

--- a/src/lib/guestOpsCoach.ts
+++ b/src/lib/guestOpsCoach.ts
@@ -1,0 +1,310 @@
+export interface GuestOpsSnapshot {
+  totalGuests: number;
+  attendingGuests: number;
+  pendingResponses: number;
+  pendingWithoutEmail: number;
+  noContact: number;
+  missingMealChoices: number;
+  missingPlusOneNames: number;
+  manualFollowUp?: number;
+  manualHandled?: number;
+}
+
+export interface GuestOpsCoachAction {
+  id: 'import-guests' | 'collect-contact' | 'collect-pending-email' | 'send-rsvp-reminder' | 'collect-meals' | 'collect-plus-ones' | 'review-manual-follow-up' | 'healthy';
+  title: string;
+  detail: string;
+  filter: string;
+  area: 'guests' | 'messages';
+  ctaLabel: string;
+  taskLabel: string;
+}
+
+export interface GuestOpsCoachSummary {
+  readinessScore: number;
+  tone: 'urgent' | 'steady' | 'healthy';
+  statusLabel: string;
+  summary: string;
+  actions: GuestOpsCoachAction[];
+  primaryAction: GuestOpsCoachAction | null;
+}
+
+export interface MessageOpsSnapshot {
+  scheduledCount: number;
+  overdueScheduledCount: number;
+  partialCount: number;
+  failedCount: number;
+  unreachedRecipientCount: number;
+}
+
+export interface MessageOpsCoachPlay {
+  id: 'review-partial' | 'review-failed' | 'run-due-scheduled' | 'collect-contact' | 'send-rsvp-reminder' | 'stage-day-of-update' | 'steady';
+  status: 'review' | 'blocked' | 'ready' | 'calm';
+  title: string;
+  detail: string;
+  actionLabel: string;
+  action:
+    | 'open-partial'
+    | 'open-failed'
+    | 'run-due-scheduled'
+    | 'open-guests'
+    | 'compose-rsvp-reminder'
+    | 'compose-day-of-update'
+    | 'none';
+}
+
+export interface MessageOpsCoachSummary {
+  pulse: string;
+  summary: string;
+  plays: MessageOpsCoachPlay[];
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function buildHealthyGuestSummary(snapshot: GuestOpsSnapshot): string {
+  if (snapshot.totalGuests === 0) {
+    return 'Bring in your guest list first so DayOf can start coaching the RSVP and messaging lanes.';
+  }
+  if (snapshot.attendingGuests > 0) {
+    return `Guest ops looks steady. ${snapshot.attendingGuests} guest${snapshot.attendingGuests === 1 ? '' : 's'} are currently marked attending, and the RSVP cleanup lane is calm.`;
+  }
+  return 'Guest ops looks steady. Contact coverage and RSVP cleanup are in a calm state right now.';
+}
+
+export function buildGuestOpsCoach(snapshot: GuestOpsSnapshot): GuestOpsCoachSummary {
+  const penalties =
+    snapshot.pendingResponses * 5 +
+    snapshot.pendingWithoutEmail * 12 +
+    snapshot.noContact * 7 +
+    snapshot.missingMealChoices * 6 +
+    snapshot.missingPlusOneNames * 5 +
+    (snapshot.manualFollowUp ?? 0) * 4;
+
+  const readinessScore = snapshot.totalGuests === 0 ? 72 : clampScore(100 - penalties);
+
+  const actions: GuestOpsCoachAction[] = [];
+
+  if (snapshot.totalGuests === 0) {
+    actions.push({
+      id: 'import-guests',
+      title: 'Bring in your first guest list',
+      detail: 'The next layer of intelligence unlocks once guests exist here.',
+      filter: 'all',
+      area: 'guests',
+      ctaLabel: 'Open guest list',
+      taskLabel: 'Import guest list',
+    });
+  }
+
+  if (snapshot.pendingWithoutEmail > 0) {
+    actions.push({
+      id: 'collect-pending-email',
+      title: 'Collect missing email addresses first',
+      detail: `${snapshot.pendingWithoutEmail} pending guest${snapshot.pendingWithoutEmail === 1 ? '' : 's'} cannot receive reminders yet.`,
+      filter: 'pending-no-email',
+      area: 'guests',
+      ctaLabel: 'Review pending without email',
+      taskLabel: 'Collect missing guest emails',
+    });
+  }
+
+  if (snapshot.noContact > 0) {
+    actions.push({
+      id: 'collect-contact',
+      title: 'Close contact gaps before the next send',
+      detail: `${snapshot.noContact} guest${snapshot.noContact === 1 ? '' : 's'} still have no email or phone on file.`,
+      filter: 'no-contact',
+      area: 'guests',
+      ctaLabel: 'Review no-contact guests',
+      taskLabel: 'Resolve missing guest contact info',
+    });
+  }
+
+  if (snapshot.pendingResponses > 0) {
+    actions.push({
+      id: 'send-rsvp-reminder',
+      title: 'Nudge the pending RSVP group',
+      detail: `${snapshot.pendingResponses} guest${snapshot.pendingResponses === 1 ? '' : 's'} still have not replied.`,
+      filter: 'pending',
+      area: 'messages',
+      ctaLabel: 'Load RSVP reminder',
+      taskLabel: 'Follow up with pending RSVPs',
+    });
+  }
+
+  if (snapshot.missingMealChoices > 0) {
+    actions.push({
+      id: 'collect-meals',
+      title: 'Collect missing meal choices',
+      detail: `${snapshot.missingMealChoices} attending guest${snapshot.missingMealChoices === 1 ? '' : 's'} still need a meal selection.`,
+      filter: 'missing-meal',
+      area: 'guests',
+      ctaLabel: 'Review meal gaps',
+      taskLabel: 'Collect missing meal choices',
+    });
+  }
+
+  if (snapshot.missingPlusOneNames > 0) {
+    actions.push({
+      id: 'collect-plus-ones',
+      title: 'Resolve unnamed plus-ones',
+      detail: `${snapshot.missingPlusOneNames} RSVP${snapshot.missingPlusOneNames === 1 ? '' : 's'} still allow a plus-one without a saved name.`,
+      filter: 'plusone-missing',
+      area: 'guests',
+      ctaLabel: 'Review plus-one gaps',
+      taskLabel: 'Collect missing plus-one names',
+    });
+  }
+
+  if ((snapshot.manualFollowUp ?? 0) > 0) {
+    actions.push({
+      id: 'review-manual-follow-up',
+      title: 'Close the manual follow-up queue',
+      detail: `${snapshot.manualFollowUp} guest${(snapshot.manualFollowUp ?? 0) === 1 ? '' : 's'} are still flagged for offline or manual RSVP follow-up.`,
+      filter: 'manual-follow-up',
+      area: 'guests',
+      ctaLabel: 'Review manual follow-up',
+      taskLabel: 'Resolve manual RSVP follow-up',
+    });
+  }
+
+  if (actions.length === 0) {
+    actions.push({
+      id: 'healthy',
+      title: 'Guest ops is in a healthy state',
+      detail: 'RSVP cleanup, contact coverage, and meal/plus-one follow-through all look steady right now.',
+      filter: 'all',
+      area: 'guests',
+      ctaLabel: 'Open guest list',
+      taskLabel: 'Guest ops is healthy',
+    });
+  }
+
+  let tone: GuestOpsCoachSummary['tone'] = 'healthy';
+  let statusLabel = 'Healthy';
+  if (actions[0]?.id === 'healthy') {
+    tone = snapshot.totalGuests === 0 ? 'steady' : 'healthy';
+    statusLabel = snapshot.totalGuests === 0 ? 'Getting started' : 'Healthy';
+  } else if (readinessScore < 65 || snapshot.pendingWithoutEmail > 0 || snapshot.noContact > 0) {
+    tone = 'urgent';
+    statusLabel = 'Needs attention';
+  } else {
+    tone = 'steady';
+    statusLabel = 'In progress';
+  }
+
+  const summary = actions[0]?.id === 'healthy'
+    ? buildHealthyGuestSummary(snapshot)
+    : `${actions[0].title} is the best next move. After that, ${actions.slice(1, 3).map((action) => action.title.toLowerCase()).join(' and ') || 'the rest of the guest lane should feel calmer'}.`;
+
+  return {
+    readinessScore,
+    tone,
+    statusLabel,
+    summary,
+    actions,
+    primaryAction: actions[0] ?? null,
+  };
+}
+
+export function buildMessageOpsCoach(guestSnapshot: GuestOpsSnapshot, messageSnapshot: MessageOpsSnapshot): MessageOpsCoachSummary {
+  const plays: MessageOpsCoachPlay[] = [];
+
+  if (messageSnapshot.partialCount > 0) {
+    plays.push({
+      id: 'review-partial',
+      status: 'review',
+      title: 'Review partial delivery first',
+      detail: `${messageSnapshot.partialCount} campaign${messageSnapshot.partialCount === 1 ? '' : 's'} landed partially, so review misses before sending a follow-up.`,
+      actionLabel: 'Review partial',
+      action: 'open-partial',
+    });
+  }
+
+  if (messageSnapshot.failedCount > 0) {
+    plays.push({
+      id: 'review-failed',
+      status: 'review',
+      title: 'Check failed campaigns next',
+      detail: `${messageSnapshot.failedCount} campaign${messageSnapshot.failedCount === 1 ? '' : 's'} fully failed and need either a retry or a cleaner re-send plan.`,
+      actionLabel: 'Review failed',
+      action: 'open-failed',
+    });
+  }
+
+  if (messageSnapshot.overdueScheduledCount > 0) {
+    plays.push({
+      id: 'run-due-scheduled',
+      status: 'ready',
+      title: 'Run past-due scheduled sends',
+      detail: `${messageSnapshot.overdueScheduledCount} scheduled campaign${messageSnapshot.overdueScheduledCount === 1 ? '' : 's'} are already due.`,
+      actionLabel: 'Run due sends',
+      action: 'run-due-scheduled',
+    });
+  }
+
+  if (guestSnapshot.pendingWithoutEmail > 0 || guestSnapshot.noContact > 0) {
+    const affected = guestSnapshot.pendingWithoutEmail > 0 ? guestSnapshot.pendingWithoutEmail : guestSnapshot.noContact;
+    plays.push({
+      id: 'collect-contact',
+      status: 'blocked',
+      title: 'Fix contact gaps before the next reminder',
+      detail: `${affected} guest${affected === 1 ? '' : 's'} still need reachable contact details before messaging can do its job cleanly.`,
+      actionLabel: 'Open guest list',
+      action: 'open-guests',
+    });
+  }
+
+  if (guestSnapshot.pendingResponses > 0) {
+    plays.push({
+      id: 'send-rsvp-reminder',
+      status: 'ready',
+      title: 'Load the next RSVP reminder',
+      detail: `${guestSnapshot.pendingResponses} guest${guestSnapshot.pendingResponses === 1 ? '' : 's'} are still pending, so the next nudge is ready to draft.`,
+      actionLabel: 'Load RSVP reminder',
+      action: 'compose-rsvp-reminder',
+    });
+  }
+
+  if (guestSnapshot.attendingGuests > 0 && messageSnapshot.scheduledCount === 0) {
+    plays.push({
+      id: 'stage-day-of-update',
+      status: 'ready',
+      title: 'Stage a day-of update now',
+      detail: `${guestSnapshot.attendingGuests} attending guest${guestSnapshot.attendingGuests === 1 ? '' : 's'} are already in play, so a ready-to-send day-of update will save time later.`,
+      actionLabel: 'Load day-of update',
+      action: 'compose-day-of-update',
+    });
+  }
+
+  const topPlays = plays.slice(0, 3);
+  if (topPlays.length === 0) {
+    return {
+      pulse: 'Steady',
+      summary: 'Messaging looks calm right now. Delivery review, contact coverage, and scheduled sends do not have an obvious hot spot.',
+      plays: [{
+        id: 'steady',
+        status: 'calm',
+        title: 'Messaging lane looks healthy',
+        detail: messageSnapshot.unreachedRecipientCount > 0
+          ? `${messageSnapshot.unreachedRecipientCount} recipient${messageSnapshot.unreachedRecipientCount === 1 ? '' : 's'} remain unreached overall, but there is no urgent send or review queue right now.`
+          : 'No urgent review queue, no past-due scheduled sends, and no obvious next-send blocker are showing right now.',
+        actionLabel: 'Stay steady',
+        action: 'none',
+      }],
+    };
+  }
+
+  const pulse = topPlays.some((play) => play.status === 'review' || play.status === 'blocked')
+    ? 'Needs attention'
+    : 'Ready to move';
+  const summary = topPlays[0].detail;
+
+  return {
+    pulse,
+    summary,
+    plays: topPlays,
+  };
+}

--- a/src/pages/dashboard/Guests.tsx
+++ b/src/pages/dashboard/Guests.tsx
@@ -27,6 +27,7 @@ import { demoWeddingSite, demoGuests, demoRSVPs } from '../../lib/demoData';
 import { buildQuickStartPhotosPath, readQuickStartDashboardContinuation } from '../../lib/quickStartContinuation';
 import { sendWeddingInvitation } from '../../lib/emailService';
 import { resolvePublicSiteSlugFromRow } from '../../lib/publicSiteSlug';
+import { buildGuestOpsCoach } from '../../lib/guestOpsCoach';
 import * as XLSX from 'xlsx';
 
 interface Guest {
@@ -3075,38 +3076,39 @@ Proceed with send?`)) return;
     pendingNoEmail: guests.filter(g => isPendingRsvpStatus(g.rsvp_status) && !g.email).length,
   };
 
+  const manualFollowUpCount = guests.filter((guest) => getRsvpFallbackState({
+    rsvpStatus: guest.rsvp_status,
+    hasEmail: Boolean(guest.email),
+    hasPhone: Boolean(guest.phone),
+    manualHandled: typeof guest.notes === 'string' && guest.notes.toLowerCase().includes('[manual rsvp]'),
+  }).state === 'manual-follow-up').length;
 
-  const recommendedAction = (() => {
-    if (rsvpOps.pendingNoEmail > 0) {
-      return {
-        filter: 'pending-no-email' as const,
-        title: 'Collect missing email addresses',
-        detail: `${rsvpOps.pendingNoEmail} pending guests can’t receive reminders yet.`,
-      };
-    }
-    if (rsvpOps.noResponse > 0) {
-      return {
-        filter: 'pending' as const,
-        title: 'Send reminder to pending guests',
-        detail: `${rsvpOps.noResponse} guests still haven’t responded.`,
-      };
-    }
-    if (rsvpOps.missingMeal > 0) {
-      return {
-        filter: 'missing-meal' as const,
-        title: 'Collect missing meal choices',
-        detail: `${rsvpOps.missingMeal} attending guests are missing meal picks.`,
-      };
-    }
-    if (rsvpOps.plusOneMissingName > 0) {
-      return {
-        filter: 'plusone-missing' as const,
-        title: 'Collect plus-one names',
-        detail: `${rsvpOps.plusOneMissingName} RSVPs allow plus-ones but names are missing.`,
-      };
-    }
-    return null;
-  })();
+  const manualHandledCount = guests.filter((guest) => getRsvpFallbackState({
+    rsvpStatus: guest.rsvp_status,
+    hasEmail: Boolean(guest.email),
+    hasPhone: Boolean(guest.phone),
+    manualHandled: typeof guest.notes === 'string' && guest.notes.toLowerCase().includes('[manual rsvp]'),
+  }).state === 'manual-handled').length;
+
+  const guestOpsCoach = buildGuestOpsCoach({
+    totalGuests: guests.length,
+    attendingGuests: guests.filter((guest) => isAttendingRsvpStatus(guest.rsvp_status)).length,
+    pendingResponses: rsvpOps.noResponse,
+    pendingWithoutEmail: rsvpOps.pendingNoEmail,
+    noContact: contactStats.withNoContact,
+    missingMealChoices: rsvpOps.missingMeal,
+    missingPlusOneNames: rsvpOps.plusOneMissingName,
+    manualFollowUp: manualFollowUpCount,
+    manualHandled: manualHandledCount,
+  });
+
+  const recommendedAction = guestOpsCoach.primaryAction
+    ? {
+        filter: guestOpsCoach.primaryAction.filter as typeof filterStatus,
+        title: guestOpsCoach.primaryAction.title,
+        detail: guestOpsCoach.primaryAction.detail,
+      }
+    : null;
 
   const rsvpCompleteness = Math.max(0, 100 - Math.min(100, (
     (rsvpOps.noResponse * 0.55) +
@@ -3848,6 +3850,59 @@ Proceed with send?`)) return;
             </ul>
           </div>
         )}
+
+        <Card variant="bordered" padding="lg" className="border-border-subtle shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="max-w-3xl">
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-semibold text-text-primary">Guest ops coach</p>
+                <Badge variant={guestOpsCoach.tone === 'urgent' ? 'error' : guestOpsCoach.tone === 'steady' ? 'warning' : 'success'}>
+                  {guestOpsCoach.statusLabel}
+                </Badge>
+              </div>
+              <p className="mt-2 text-sm text-text-secondary">{guestOpsCoach.summary}</p>
+            </div>
+            <div className="rounded-2xl border border-border-subtle bg-surface-subtle/30 px-4 py-3 lg:min-w-[180px]">
+              <p className="text-[11px] uppercase tracking-[0.22em] text-text-tertiary">Readiness</p>
+              <p className="mt-1 text-2xl font-semibold text-text-primary">{guestOpsCoach.readinessScore}%</p>
+              <p className="mt-1 text-xs text-text-secondary">How ready the RSVP and follow-up lane feels right now.</p>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            {guestOpsCoach.actions.slice(0, 3).map((action) => (
+              <div key={action.id} className="rounded-2xl border border-border-subtle bg-white px-4 py-4 shadow-[0_4px_14px_rgba(15,23,42,0.04)]">
+                <p className="text-sm font-semibold text-text-primary">{action.title}</p>
+                <p className="mt-2 text-xs leading-5 text-text-secondary">{action.detail}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      if (action.area === 'messages') {
+                        navigate('/dashboard/messages');
+                        return;
+                      }
+                      setFilterStatus(action.filter as typeof filterStatus);
+                      setViewMode('list');
+                      setSearchQuery('');
+                    }}
+                  >
+                    {action.ctaLabel}
+                  </Button>
+                  {action.id !== 'healthy' && action.id !== 'import-guests' && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => addFollowUpTask(action.taskLabel)}
+                    >
+                      Save task
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
 
         <Card variant="bordered" padding="lg">
           <div className="space-y-6">

--- a/src/pages/dashboard/Messages.tsx
+++ b/src/pages/dashboard/Messages.tsx
@@ -14,6 +14,7 @@ import { GUEST_COMMUNICATION_FLOW } from '../../lib/guestCommunicationFlow';
 import { buildRsvpReminderDraft } from '../../lib/reminderDraftHelper';
 import { buildDayOfUpdateDraft } from '../../lib/dayOfUpdateHelper';
 import { buildEventReminderDraft } from '../../lib/eventReminderHelper';
+import { buildGuestOpsCoach, buildMessageOpsCoach } from '../../lib/guestOpsCoach';
 import { formatMessageEventOptionLabel } from './messageEventDate';
 import { formatMessageHistoryDate, formatMessageHistoryDateTime, getMessageHistoryTimestamp } from './messageHistoryTime';
 import { formatScheduledMessageDateTime, parseScheduleInputToIso, toScheduleInputValue } from './messageScheduleTime';
@@ -2230,6 +2231,72 @@ export const DashboardMessages: React.FC = () => {
     }));
   }
 
+  function runMessageOpsCoachPlay(play: ReturnType<typeof buildMessageOpsCoach>['plays'][number]) {
+    if (play.action === 'open-partial') {
+      if (reviewCandidates[0]) {
+        setViewingMessage(reviewCandidates[0]);
+      } else {
+        setHistoryStatusFilter('partial');
+        setHistoryChannelFilter('all');
+      }
+      return;
+    }
+
+    if (play.action === 'open-failed') {
+      if (retryCandidates[0]) {
+        setViewingMessage(retryCandidates[0]);
+      } else {
+        setHistoryStatusFilter('failed');
+        setHistoryChannelFilter('all');
+      }
+      return;
+    }
+
+    if (play.action === 'run-due-scheduled') {
+      void handleRunDueScheduledMessages();
+      return;
+    }
+
+    if (play.action === 'open-guests') {
+      navigate('/dashboard/guests');
+      return;
+    }
+
+    if (!canCompose) {
+      toast('Composer actions stay with the couple or planner in this access view.', 'info');
+      return;
+    }
+
+    if (play.action === 'compose-rsvp-reminder') {
+      applyComposerTemplate('rsvp-reminder', {
+        audience: 'not_responded',
+        channel: 'email',
+        scheduleType: 'now',
+        scheduleDate: '',
+        scheduleTime: '',
+        campaignName: 'RSVP follow-up',
+      });
+      setShowRecipientPreview(true);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      toast('Loaded an RSVP reminder into the composer.', 'info');
+      return;
+    }
+
+    if (play.action === 'compose-day-of-update') {
+      applyComposerTemplate('day-of-update', {
+        audience: 'attending',
+        channel: 'sms',
+        scheduleType: 'now',
+        scheduleDate: '',
+        scheduleTime: '',
+        campaignName: 'Day-of update',
+      });
+      setShowRecipientPreview(true);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      toast('Loaded a day-of update into the composer.', 'info');
+    }
+  }
+
   function applySavedTemplate(template: SavedComposerTemplate) {
     setEditingMessageId(null);
     const savedScheduleIsUsable = isSavedTemplateScheduleUsable(template);
@@ -2572,6 +2639,32 @@ export const DashboardMessages: React.FC = () => {
     return { successRate, failRate, skipped, skippedRate, overdueScheduled, retryBacklog, reviewBacklog };
   }, [messages, deliveries]);
 
+  const guestOpsCoach = useMemo(() => buildGuestOpsCoach({
+    totalGuests: guests.length,
+    attendingGuests: guests.filter((guest) => isAttendingStatus(guest.rsvp_status)).length,
+    pendingResponses: guests.filter((guest) => isPendingStatus(guest.rsvp_status)).length,
+    pendingWithoutEmail: guests.filter((guest) => isPendingStatus(guest.rsvp_status) && !hasReachableEmail(guest.email)).length,
+    noContact: guests.filter((guest) => !hasReachableEmail(guest.email) && !hasReachablePhone(guest.phone)).length,
+    missingMealChoices: 0,
+    missingPlusOneNames: 0,
+  }), [guests]);
+
+  const messageOpsCoach = useMemo(() => buildMessageOpsCoach({
+    totalGuests: guests.length,
+    attendingGuests: guests.filter((guest) => isAttendingStatus(guest.rsvp_status)).length,
+    pendingResponses: guests.filter((guest) => isPendingStatus(guest.rsvp_status)).length,
+    pendingWithoutEmail: guests.filter((guest) => isPendingStatus(guest.rsvp_status) && !hasReachableEmail(guest.email)).length,
+    noContact: guests.filter((guest) => !hasReachableEmail(guest.email) && !hasReachablePhone(guest.phone)).length,
+    missingMealChoices: 0,
+    missingPlusOneNames: 0,
+  }, {
+    scheduledCount: historyStatusCounts.scheduled,
+    overdueScheduledCount: deliveryHealth.overdueScheduled,
+    partialCount: historyStatusCounts.partial,
+    failedCount: historyStatusCounts.failed,
+    unreachedRecipientCount: messages.reduce((sum, message) => sum + getUnreachedCount(message, deliveries), 0),
+  }), [deliveryHealth.overdueScheduled, deliveries, guests, historyStatusCounts.failed, historyStatusCounts.partial, historyStatusCounts.scheduled, messages]);
+
   const campaignThreads = useMemo(() => {
     const map = new Map<string, {
       key: string;
@@ -2763,6 +2856,53 @@ export const DashboardMessages: React.FC = () => {
                 <p className="text-[11px] uppercase tracking-[0.22em] text-text-tertiary">0{index + 1}</p>
                 <p className="mt-2 text-sm font-semibold text-text-primary">{stage.label}</p>
                 <p className="mt-2 text-xs leading-5 text-text-secondary">{stage.detail}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-[28px] border border-border-subtle bg-white p-5 shadow-sm">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="max-w-3xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-text-tertiary">Suggested next moves</p>
+              <h2 className="mt-2 text-2xl font-semibold text-text-primary">{messageOpsCoach.pulse}</h2>
+              <p className="mt-2 text-sm text-text-secondary">{messageOpsCoach.summary}</p>
+            </div>
+            <div className="rounded-2xl border border-border-subtle bg-surface-subtle/30 px-4 py-3 md:min-w-[220px]">
+              <p className="text-[11px] uppercase tracking-[0.22em] text-text-tertiary">Guest ops readiness</p>
+              <p className="mt-1 text-2xl font-semibold text-text-primary">{guestOpsCoach.readinessScore}%</p>
+              <p className="mt-1 text-xs text-text-secondary">Shared guest and messaging confidence, so the next send is based on the real state of the list.</p>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 md:grid-cols-3">
+            {messageOpsCoach.plays.map((play) => (
+              <div key={play.id} className="rounded-2xl border border-border-subtle bg-surface-subtle/20 px-4 py-4">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-sm font-semibold text-text-primary">{play.title}</p>
+                  <span className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${
+                    play.status === 'review'
+                      ? 'border border-warning/20 bg-warning-light text-warning'
+                      : play.status === 'blocked'
+                        ? 'border border-error/20 bg-error-light text-error'
+                        : play.status === 'ready'
+                          ? 'border border-primary/20 bg-primary-light text-primary'
+                          : 'border border-success/20 bg-success-light text-success'
+                  }`}>
+                    {play.status === 'review' ? 'Review' : play.status === 'blocked' ? 'Blocked' : play.status === 'ready' ? 'Ready' : 'Calm'}
+                  </span>
+                </div>
+                <p className="mt-2 text-xs leading-5 text-text-secondary">{play.detail}</p>
+                {play.action !== 'none' && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="mt-3"
+                    disabled={!canCompose && (play.action === 'compose-rsvp-reminder' || play.action === 'compose-day-of-update' || play.action === 'run-due-scheduled')}
+                    onClick={() => runMessageOpsCoachPlay(play)}
+                  >
+                    {play.actionLabel}
+                  </Button>
+                )}
               </div>
             ))}
           </div>

--- a/src/pages/dashboard/Overview.tsx
+++ b/src/pages/dashboard/Overview.tsx
@@ -29,6 +29,7 @@ import { getArchiveModeDescriptor } from '../../lib/archiveMode';
 import { hasRespondedRsvpStatus, isAttendingRsvpStatus, isDeclinedRsvpStatus, isPendingRsvpStatus } from '../../lib/rsvpStatus';
 import { writeOnboardingResumeTarget } from '../../lib/onboardingResumeStorage';
 import { useToast } from '../../components/ui/Toast';
+import { buildGuestOpsCoach } from '../../lib/guestOpsCoach';
 import { calcOverviewDaysUntil, formatOverviewRelativeTime, formatOverviewWeddingDate, getOverviewTimestamp } from './overviewDate';
 import { getOverviewFallbackCoupleValue } from './overviewDraftBrief';
 import { buildNameChangeOverviewCardModel } from './nameChangeOverviewCard';
@@ -519,6 +520,16 @@ export const DashboardOverview: React.FC = () => {
     interactiveSuggestionCount: interactiveSuggestions.length,
   });
 
+  const guestOpsCoach = buildGuestOpsCoach({
+    totalGuests: stats?.totalGuests ?? 0,
+    attendingGuests: stats?.confirmedGuests ?? 0,
+    pendingResponses: stats?.pendingGuests ?? 0,
+    pendingWithoutEmail: 0,
+    noContact: stats ? Math.max((stats.totalGuests ?? 0) - (stats.contactableGuestCount ?? 0), 0) : 0,
+    missingMealChoices: 0,
+    missingPlusOneNames: 0,
+  });
+
   const hideSuggestion = async (id: string) => {
     const { error } = await supabase.from('interactive_suggestions').update({ is_hidden: true }).eq('id', id);
     if (error) {
@@ -797,11 +808,30 @@ export const DashboardOverview: React.FC = () => {
                     </div>
                   </div>
                   <div className="rounded-xl border border-border-subtle bg-white px-4 py-4">
-                    <p className="text-sm font-semibold text-text-primary">Where to push next</p>
-                    <div className="mt-3 space-y-2 text-sm text-text-secondary">
-                      <p>{(stats?.pendingGuests ?? 0) > 0 ? `${stats?.pendingGuests ?? 0} guests still need an RSVP reply.` : 'RSVP backlog is clear right now.'}</p>
-                      <p>{(stats?.contactableGuestCount ?? 0) < (stats?.totalGuests ?? 0) ? `${(stats?.totalGuests ?? 0) - (stats?.contactableGuestCount ?? 0)} guests still need contact coverage.` : 'Guest contact coverage looks complete.'}</p>
-                      <p>{(stats?.registryItemCount ?? 0) === 0 ? 'Registry still needs live items.' : 'Registry has enough live items to be guest-facing.'}</p>
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-text-primary">Guest ops coach</p>
+                        <p className="mt-1 text-xs text-text-secondary">{guestOpsCoach.summary}</p>
+                      </div>
+                      <Badge variant={guestOpsCoach.tone === 'urgent' ? 'error' : guestOpsCoach.tone === 'steady' ? 'warning' : 'success'}>
+                        {guestOpsCoach.statusLabel}
+                      </Badge>
+                    </div>
+                    <div className="mt-3 space-y-2">
+                      {guestOpsCoach.actions.slice(0, 3).map((action) => (
+                        <button
+                          key={action.id}
+                          type="button"
+                          onClick={() => navigate(action.area === 'messages' ? '/dashboard/messages' : '/dashboard/guests')}
+                          className="w-full rounded-lg border border-border-subtle bg-surface-secondary/20 px-3 py-2 text-left hover:border-primary/30 hover:bg-white"
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <span className="text-sm font-medium text-text-primary">{action.title}</span>
+                            <span className="text-[11px] text-primary">{action.ctaLabel}</span>
+                          </div>
+                          <p className="mt-1 text-xs text-text-secondary">{action.detail}</p>
+                        </button>
+                      ))}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## What changed
- added a shared `guestOpsCoach` helper to turn guest and messaging state into a small set of prioritized next actions
- upgraded the dashboard overview with a compact Guest ops coach card
- upgraded Guests with a readiness summary and the top next actions, while preserving the existing deeper workflow
- upgraded Messages with suggested next moves tied to real delivery and guest-state conditions

## Why
We want these surfaces to feel more like a calm operating system and less like isolated tools. This batch adds useful intelligence without making the UI busier or more complex.

## Product impact
- couples and planners get clearer guidance on what to do next
- guest ops and messaging stay connected, so the next send reflects real RSVP and contact state
- the UI stays intentionally restrained: one compact summary card per surface rather than a new dense dashboard layer

## Validation
- `npm test -- --run src/lib/guestOpsCoach.test.ts`
- `npm run build`
- `git diff --check -- src/lib/guestOpsCoach.ts src/lib/guestOpsCoach.test.ts src/pages/dashboard/Overview.tsx src/pages/dashboard/Guests.tsx src/pages/dashboard/Messages.tsx`

## Notes
- broader repo-wide typecheck/lint remains noisy because of unrelated pre-existing local duplicate clutter and existing non-batch issues
- unrelated untracked duplicate files were intentionally left out of this PR