### PR TITLE
Unify the guest journey across public flows

### DIFF
--- a/src/components/guest/GuestJourneyCompanion.test.tsx
+++ b/src/components/guest/GuestJourneyCompanion.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+import { GuestJourneyCompanion } from './GuestJourneyCompanion';
+
+describe('GuestJourneyCompanion', () => {
+  it('renders next-step guest links without repeating the current surface', () => {
+    render(
+      <GuestJourneyCompanion
+        currentSurface="contact"
+        siteSlug="ericandkaras"
+        inviteToken="invite-123"
+        previewGuest="guest-42"
+        isHubEntry
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: /update details without losing your place/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Wedding hub' })).toHaveAttribute('href', '/site/ericandkaras?previewGuest=guest-42&previewSurface=public&token=invite-123');
+    expect(screen.getByRole('link', { name: 'Travel details' })).toHaveAttribute('href', '/site/ericandkaras?previewGuest=guest-42&previewSurface=travel&token=invite-123#travel');
+    expect(screen.getByRole('link', { name: 'RSVP' })).toHaveAttribute('href', '/rsvp?site=ericandkaras&token=invite-123');
+    expect(screen.getByRole('link', { name: 'Upload photos' })).toHaveAttribute('href', '/photos/upload?site=ericandkaras&t=invite-123&hub=1&previewGuest=guest-42&previewSurface=photos');
+    expect(screen.queryByRole('link', { name: 'Update details' })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/guest/GuestJourneyCompanion.tsx
+++ b/src/components/guest/GuestJourneyCompanion.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { buildGuestJourneyLinks, getGuestJourneyCopy, type GuestJourneyContext } from '../../lib/guestJourney';
+
+type GuestJourneyCompanionProps = GuestJourneyContext & {
+  className?: string;
+};
+
+export const GuestJourneyCompanion: React.FC<GuestJourneyCompanionProps> = ({
+  className = '',
+  ...context
+}) => {
+  const links = buildGuestJourneyLinks(context);
+  if (links.length === 0) return null;
+
+  const copy = getGuestJourneyCopy(context.currentSurface);
+
+  return (
+    <section
+      aria-label="Guest journey"
+      className={`rounded-2xl border border-border-subtle bg-surface-subtle/50 p-4 sm:p-5 ${className}`.trim()}
+    >
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-tertiary">Guest path</p>
+      <h2 className="mt-2 text-lg font-semibold text-text-primary">{copy.title}</h2>
+      <p className="mt-1.5 text-sm leading-6 text-text-secondary">{copy.detail}</p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {links.map((link) => (
+          <Link
+            key={link.key}
+            to={link.href}
+            className="inline-flex min-h-[40px] items-center rounded-full border border-border bg-white px-3.5 py-2 text-sm font-medium text-text-primary transition hover:border-primary/40 hover:text-primary"
+          >
+            {link.label}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/lib/guestJourney.test.ts
+++ b/src/lib/guestJourney.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildGuestJourneyLinks, getGuestJourneyCopy } from './guestJourney';
+
+describe('guestJourney', () => {
+  it('builds stable guest journey links from a site slug and invite token', () => {
+    const links = buildGuestJourneyLinks({
+      currentSurface: 'photos',
+      siteSlug: 'ericandkaras',
+      inviteToken: 'invite-123',
+      previewGuest: 'guest-42',
+      isHubEntry: true,
+    });
+
+    expect(links.map((link) => link.key)).toEqual(['hub', 'travel', 'rsvp', 'contact']);
+    expect(links.find((link) => link.key === 'hub')?.href).toBe('/site/ericandkaras?previewGuest=guest-42&previewSurface=public&token=invite-123');
+    expect(links.find((link) => link.key === 'travel')?.href).toBe('/site/ericandkaras?previewGuest=guest-42&previewSurface=travel&token=invite-123#travel');
+    expect(links.find((link) => link.key === 'rsvp')?.href).toBe('/rsvp?site=ericandkaras&token=invite-123');
+    expect(links.find((link) => link.key === 'contact')?.href).toBe('/guest-contact/ericandkaras?previewGuest=guest-42&previewSurface=contact');
+  });
+
+  it('drops links when the route does not have a site slug to carry forward', () => {
+    expect(buildGuestJourneyLinks({ currentSurface: 'rsvp' })).toEqual([]);
+  });
+
+  it('keeps the guest path copy intentional for vault surfaces', () => {
+    expect(getGuestJourneyCopy('vault')).toEqual({
+      title: 'The story stretches past the wedding weekend',
+      detail: 'Anniversary notes live later in the story, but the wedding hub, RSVP, travel details, and photos should still be easy to reopen from here.',
+    });
+  });
+});

--- a/src/lib/guestJourney.ts
+++ b/src/lib/guestJourney.ts
@@ -1,0 +1,154 @@
+export type GuestJourneySurface = 'rsvp' | 'travel' | 'photos' | 'contact' | 'vault';
+
+export interface GuestJourneyLink {
+  key: 'hub' | 'travel' | 'rsvp' | 'photos' | 'contact';
+  label: string;
+  href: string;
+}
+
+export interface GuestJourneyContext {
+  currentSurface: GuestJourneySurface;
+  siteSlug?: string | null;
+  inviteToken?: string | null;
+  previewGuest?: string | null;
+  isHubEntry?: boolean;
+}
+
+export interface GuestJourneyCopy {
+  title: string;
+  detail: string;
+}
+
+function toSearchString(params: URLSearchParams): string {
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+function appendPreviewParams(
+  params: URLSearchParams,
+  previewGuest: string | null | undefined,
+  previewSurface?: string,
+) {
+  if (previewGuest) {
+    params.set('previewGuest', previewGuest);
+  }
+  if (previewSurface) {
+    params.set('previewSurface', previewSurface);
+  }
+}
+
+export function getGuestJourneyCopy(surface: GuestJourneySurface): GuestJourneyCopy {
+  switch (surface) {
+    case 'rsvp':
+      return {
+        title: 'Everything stays on the same guest path',
+        detail: 'Reply here, then jump to travel, photos, or contact updates from the same wedding path whenever you need them.',
+      };
+    case 'photos':
+      return {
+        title: 'Share now, keep the rest within reach',
+        detail: 'Photo sharing does not strand you. RSVP, travel details, and contact updates should still feel like part of one calm guest flow.',
+      };
+    case 'contact':
+      return {
+        title: 'Update details without losing your place',
+        detail: 'You can handle contact updates here, then head back to RSVP, travel details, or photo sharing from the same wedding path.',
+      };
+    case 'vault':
+      return {
+        title: 'The story stretches past the wedding weekend',
+        detail: 'Anniversary notes live later in the story, but the wedding hub, RSVP, travel details, and photos should still be easy to reopen from here.',
+      };
+    case 'travel':
+      return {
+        title: 'Travel is part of the same guest journey',
+        detail: 'Guests should be able to move from travel details to RSVP, photos, and updates without feeling like they entered a different tool.',
+      };
+    default:
+      return {
+        title: 'Everything guests need stays connected',
+        detail: 'The wedding path should keep RSVP, updates, travel, and photos easy to reopen from one place.',
+      };
+  }
+}
+
+export function buildGuestJourneyLinks(context: GuestJourneyContext): GuestJourneyLink[] {
+  const { currentSurface, siteSlug, inviteToken, previewGuest, isHubEntry } = context;
+  const normalizedSlug = siteSlug?.trim().toLowerCase() || '';
+  if (!normalizedSlug) return [];
+
+  const links: GuestJourneyLink[] = [];
+
+  const hubParams = new URLSearchParams();
+  appendPreviewParams(hubParams, previewGuest, 'public');
+  if (inviteToken) {
+    hubParams.set('token', inviteToken);
+  }
+  links.push({
+    key: 'hub',
+    label: 'Wedding hub',
+    href: `/site/${normalizedSlug}${toSearchString(hubParams)}`,
+  });
+
+  const travelParams = new URLSearchParams();
+  appendPreviewParams(travelParams, previewGuest, 'travel');
+  if (inviteToken) {
+    travelParams.set('token', inviteToken);
+  }
+  links.push({
+    key: 'travel',
+    label: 'Travel details',
+    href: `/site/${normalizedSlug}${toSearchString(travelParams)}#travel`,
+  });
+
+  const rsvpParams = new URLSearchParams();
+  rsvpParams.set('site', normalizedSlug);
+  if (inviteToken) {
+    rsvpParams.set('token', inviteToken);
+  }
+  links.push({
+    key: 'rsvp',
+    label: 'RSVP',
+    href: `/rsvp${toSearchString(rsvpParams)}`,
+  });
+
+  const photoParams = new URLSearchParams();
+  photoParams.set('site', normalizedSlug);
+  if (inviteToken) {
+    photoParams.set('t', inviteToken);
+  }
+  if (isHubEntry) {
+    photoParams.set('hub', '1');
+  }
+  appendPreviewParams(photoParams, previewGuest, 'photos');
+  links.push({
+    key: 'photos',
+    label: 'Upload photos',
+    href: `/photos/upload${toSearchString(photoParams)}`,
+  });
+
+  const contactParams = new URLSearchParams();
+  appendPreviewParams(contactParams, previewGuest, 'contact');
+  links.push({
+    key: 'contact',
+    label: 'Update details',
+    href: `/guest-contact/${normalizedSlug}${toSearchString(contactParams)}`,
+  });
+
+  return links.filter((link) => {
+    switch (currentSurface) {
+      case 'travel':
+        return link.key !== 'travel';
+      case 'rsvp':
+        return link.key !== 'rsvp';
+      case 'photos':
+        return link.key !== 'photos';
+      case 'contact':
+        return link.key !== 'contact';
+      case 'vault':
+        return true;
+      default:
+        return true;
+    }
+  });
+}

--- a/src/pages/GuestContactUpdate.tsx
+++ b/src/pages/GuestContactUpdate.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { GuestJourneyCompanion } from '../components/guest/GuestJourneyCompanion';
 import { demoGuests, demoWeddingSite } from '../lib/demoData';
 
 type Match = {
@@ -37,8 +38,11 @@ async function callPublicFn(name: string, body: unknown) {
 
 export const GuestContactUpdate: React.FC = () => {
   const { token = '' } = useParams<{ token: string }>();
+  const params = useMemo(() => new URLSearchParams(window.location.search), []);
   const siteRef = token; // now interpreted as site id/slug
   const isDemoSiteRef = siteRef === demoWeddingSite.id || siteRef.toLowerCase() === 'demo';
+  const previewGuest = params.get('previewGuest')?.trim() ?? '';
+  const inviteToken = params.get('invite_token')?.trim() ?? '';
 
   const [query, setQuery] = useState('');
   const [matches, setMatches] = useState<Match[]>([]);
@@ -153,6 +157,14 @@ export const GuestContactUpdate: React.FC = () => {
       <div className="w-full max-w-xl bg-surface border border-border rounded-2xl p-6 space-y-4">
         <h1 className="text-xl font-semibold text-text-primary">Update contact & RSVP</h1>
         <p className="text-sm text-text-secondary">Search your name, choose your record, then update details for yourself or your party.</p>
+
+        <GuestJourneyCompanion
+          currentSurface="contact"
+          siteSlug={siteRef || undefined}
+          inviteToken={inviteToken || undefined}
+          previewGuest={previewGuest || undefined}
+          className="mt-4"
+        />
 
         <div className="flex gap-2">
           <input

--- a/src/pages/PhotoUpload.tsx
+++ b/src/pages/PhotoUpload.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { GuestJourneyCompanion } from '../components/guest/GuestJourneyCompanion';
 
 const supabaseUrl = (import.meta.env.VITE_SUPABASE_URL as string | undefined)?.trim();
 const supabaseAnonKey = (import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined)?.trim();
@@ -28,6 +29,9 @@ export const PhotoUpload: React.FC = () => {
   const params = useMemo(() => new URLSearchParams(window.location.search), []);
   const initialToken = params.get('t')?.trim() ?? '';
   const siteSlug = params.get('site')?.trim().toLowerCase() ?? '';
+  const previewGuest = params.get('previewGuest')?.trim() ?? '';
+  const inviteToken = params.get('invite_token')?.trim() || initialToken;
+  const isHubEntry = params.get('hub') === '1';
 
   const [token, setToken] = useState(initialToken);
   const [guestName, setGuestName] = useState('');
@@ -117,6 +121,15 @@ export const PhotoUpload: React.FC = () => {
             Uploading to {siteSlug}.dayof.love
           </p>
         )}
+
+        <GuestJourneyCompanion
+          currentSurface="photos"
+          siteSlug={siteSlug || undefined}
+          inviteToken={inviteToken || undefined}
+          previewGuest={previewGuest || undefined}
+          isHubEntry={isHubEntry}
+          className="mt-5 border-rose-100 bg-rose-50/45"
+        />
 
         <form onSubmit={onSubmit} className="mt-6 space-y-4">
           {!siteSlug && (

--- a/src/pages/RSVP.tsx
+++ b/src/pages/RSVP.tsx
@@ -6,6 +6,7 @@ import { Input } from '../components/ui/Input';
 import { Select } from '../components/ui/Select';
 import { Textarea } from '../components/ui/Textarea';
 import { Card } from '../components/ui/Card';
+import { GuestJourneyCompanion } from '../components/guest/GuestJourneyCompanion';
 import { LanguageSwitcher } from '../components/ui/LanguageSwitcher';
 import { CheckCircle, Search, AlertCircle, User } from 'lucide-react';
 import { demoGuests, demoRSVPs } from '../lib/demoData';
@@ -443,6 +444,8 @@ export default function RSVP() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const siteSlug = searchParams.get('site')?.trim().toLowerCase() ?? '';
+  const previewGuest = searchParams.get('previewGuest')?.trim() ?? '';
   const [step, setStep] = useState<'search' | 'pick' | 'form' | 'success'>('search');
   const [searchValue, setSearchValue] = useState('');
   const [guest, setGuest] = useState<Guest | null>(null);
@@ -1411,6 +1414,14 @@ export default function RSVP() {
                 </div>
               </>
             )}
+
+            <GuestJourneyCompanion
+              currentSurface="rsvp"
+              siteSlug={siteSlug || undefined}
+              inviteToken={activeToken || undefined}
+              previewGuest={previewGuest || undefined}
+              className="mb-6"
+            />
 
             {deadlinePassed && existingRsvp && (
               <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-lg text-amber-800 text-sm flex items-start gap-2">

--- a/src/pages/VaultContribute.tsx
+++ b/src/pages/VaultContribute.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { Lock, Heart, Send, CheckCircle, AlertCircle, Loader2, Mic, Square } from 'lucide-react';
+import { GuestJourneyCompanion } from '../components/guest/GuestJourneyCompanion';
 import { supabase } from '../lib/supabase';
 import { DEMO_MODE } from '../config/env';
 import { buildCoupleDisplayName } from '../lib/coupleDisplayName';
@@ -103,6 +104,7 @@ function ordinalLabel(years: number): string {
 export const VaultContribute: React.FC = () => {
   const { siteSlug, year } = useParams<{ siteSlug: string; year: string }>();
   const navigate = useNavigate();
+  const params = useMemo(() => new URLSearchParams(window.location.search), []);
   const [site, setSite] = useState<SiteInfo | null>(null);
   const [vaultConfig, setVaultConfig] = useState<VaultConfigInfo | null>(null);
   const [vaultOptions, setVaultOptions] = useState<VaultConfigInfo[]>([]);
@@ -131,6 +133,8 @@ export const VaultContribute: React.FC = () => {
 
   const hasYearParam = typeof year === 'string' && year.length > 0;
   const vaultYear = hasYearParam ? parseInt(year ?? '0', 10) : null;
+  const previewGuest = params.get('previewGuest')?.trim() ?? '';
+  const inviteToken = params.get('invite_token')?.trim() ?? '';
 
 
   const submittedKey = `${VAULT_SUBMITTED_KEY_PREFIX}${siteSlug ?? 'unknown'}`;
@@ -688,6 +692,14 @@ export const VaultContribute: React.FC = () => {
                 );
               })}
             </div>
+
+            <GuestJourneyCompanion
+              currentSurface="vault"
+              siteSlug={siteSlug || undefined}
+              inviteToken={inviteToken || undefined}
+              previewGuest={previewGuest || undefined}
+              className="mt-6 bg-white/90"
+            />
           </div>
         </div>
       </div>
@@ -769,6 +781,13 @@ export const VaultContribute: React.FC = () => {
 
           <div className="bg-white/95 backdrop-blur rounded-3xl shadow-xl border border-border-subtle p-5 sm:p-6 md:p-8 relative overflow-hidden transition-shadow duration-300 hover:shadow-2xl">
             <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary/20 via-primary/60 to-primary/20" />
+            <GuestJourneyCompanion
+              currentSurface="vault"
+              siteSlug={siteSlug || undefined}
+              inviteToken={inviteToken || undefined}
+              previewGuest={previewGuest || undefined}
+              className="mb-5 bg-primary/[0.03]"
+            />
             <form onSubmit={handleSubmit} className="space-y-5 md:space-y-5.5">
               <div className="text-xs rounded-xl px-3 py-2 border bg-stone-50 border-stone-200 text-stone-600">
                 Storage destination: <strong className="text-stone-800">{usingGoogleDrive ? 'Google Drive' : 'Secure vault storage'}</strong>


### PR DESCRIPTION
## Summary
- add a shared guest journey helper that preserves site, preview, and invite-link context across public guest flows
- add a reusable guest companion card and wire it into RSVP, guest contact updates, photo upload, and vault contribution
- keep the guest path smarter without adding a new complex surface

## Verification
- npm test -- --run src/lib/guestJourney.test.ts src/components/guest/GuestJourneyCompanion.test.tsx
- npm run build
- git diff --check
