### PR TITLE
Add a planning decision assistant across tabs

### DIFF
--- a/src/pages/dashboard/planning/BudgetTab.tsx
+++ b/src/pages/dashboard/planning/BudgetTab.tsx
@@ -3,6 +3,8 @@ import { Plus, Edit2, Trash2, AlertTriangle } from 'lucide-react';
 import { Card } from '../../../components/ui/Card';
 import { Button } from '../../../components/ui/Button';
 import { PlanningBudgetItem, PlanningVendor } from './planningService';
+import { PlanningDecisionCard } from './PlanningDecisionCard';
+import { buildBudgetDecisionCard } from './planningDecisionAssistant';
 
 interface Props {
   items: PlanningBudgetItem[];
@@ -189,7 +191,6 @@ export const BudgetTab: React.FC<Props> = ({ items, vendors, totalBudget, onTota
 
   const totalEstimated = items.reduce((s, i) => s + (i.estimated_amount || 0), 0);
   const totalActual = items.reduce((s, i) => s + (i.actual_amount || 0), 0);
-  const totalPaid = items.reduce((s, i) => s + (i.paid_amount || 0), 0);
   const remaining = (totalBudget || 0) - totalActual;
   const usedPct = totalBudget > 0 ? Math.min(100, Math.max(0, (totalActual / totalBudget) * 100)) : 0;
 
@@ -199,9 +200,12 @@ export const BudgetTab: React.FC<Props> = ({ items, vendors, totalBudget, onTota
     const act = items.filter(i => i.category === cat).reduce((s, i) => s + i.actual_amount, 0);
     return act > est && est > 0;
   });
+  const budgetDecision = buildBudgetDecisionCard(items, totalBudget);
 
   return (
     <div className="space-y-4">
+      <PlanningDecisionCard model={budgetDecision} />
+
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         {[
           { label: 'Budget goal', value: totalBudget || 0, color: 'text-text-primary', format: 'currency' },

--- a/src/pages/dashboard/planning/PlanningDecisionCard.tsx
+++ b/src/pages/dashboard/planning/PlanningDecisionCard.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Brain, ArrowRight } from 'lucide-react';
+import { Card } from '../../../components/ui/Card';
+import type { PlanningDecisionCardModel } from './planningDecisionAssistant';
+
+interface Props {
+  model: PlanningDecisionCardModel;
+  onAction?: (target: PlanningDecisionCardModel['primaryAction'] extends infer T ? T extends { target: infer U } ? U : never : never) => void;
+}
+
+export const PlanningDecisionCard: React.FC<Props> = ({ model, onAction }) => {
+  const handleAction = (target: Props['onAction'] extends (...args: infer A) => unknown ? A[0] : never) => {
+    onAction?.(target);
+  };
+
+  return (
+    <Card padding="md" className="border-primary/20 bg-primary/[0.04]">
+      <div className="flex items-start gap-3">
+        <div className="rounded-xl bg-primary/10 p-2">
+          <Brain className="h-5 w-5 text-primary" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-secondary">{model.eyebrow}</p>
+          <h3 className="mt-1 text-base font-semibold text-text-primary">{model.title}</h3>
+          <p className="mt-1.5 text-sm leading-6 text-text-secondary">{model.detail}</p>
+          {model.badges.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-text-secondary">
+              {model.badges.map((badge) => (
+                <span key={badge} className="rounded-full bg-white px-2.5 py-1 shadow-sm">
+                  {badge}
+                </span>
+              ))}
+            </div>
+          )}
+          {(model.primaryAction || model.secondaryAction) && onAction && (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {model.primaryAction ? (
+                <button
+                  type="button"
+                  onClick={() => handleAction(model.primaryAction?.target)}
+                  className="inline-flex min-h-[38px] items-center rounded-full bg-primary px-3.5 py-2 text-sm font-medium text-white transition hover:bg-primary-hover"
+                >
+                  {model.primaryAction.label}
+                  <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+                </button>
+              ) : null}
+              {model.secondaryAction ? (
+                <button
+                  type="button"
+                  onClick={() => handleAction(model.secondaryAction?.target)}
+                  className="inline-flex min-h-[38px] items-center rounded-full border border-border bg-white px-3.5 py-2 text-sm font-medium text-text-primary transition hover:border-primary/40 hover:text-primary"
+                >
+                  {model.secondaryAction.label}
+                </button>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/src/pages/dashboard/planning/PlanningOverviewTab.tsx
+++ b/src/pages/dashboard/planning/PlanningOverviewTab.tsx
@@ -14,6 +14,8 @@ import { isTaskDueBetween, isTaskDueOnOrBefore } from './taskDueDate';
 import { buildNameChangeOverviewCardModel } from '../nameChangeOverviewCard';
 import { buildNameChangeOverviewInsights } from '../nameChangeOverviewInsights';
 import { deriveNameChangeLifecycleStatus } from '../nameChangeLifecycleStatus';
+import { PlanningDecisionCard } from './PlanningDecisionCard';
+import { buildPlanningOverviewDecisionCard } from './planningDecisionAssistant';
 
 interface SeatingReadiness {
   attending: number;
@@ -123,9 +125,28 @@ export const PlanningOverviewTab: React.FC<Props> = ({ tasks, budgetItems, vendo
       nameChangePlan,
     ),
   );
+  const planningDecision = buildPlanningOverviewDecisionCard({
+    tasks,
+    budgetItems,
+    vendors,
+    seatingReadiness,
+  });
 
   return (
     <div className="space-y-6">
+      <PlanningDecisionCard
+        model={planningDecision}
+        onAction={(target) => {
+          if (target === 'seating') {
+            if (typeof window !== 'undefined') {
+              window.location.assign('/dashboard/seating');
+            }
+            return;
+          }
+          onTabChange(target);
+        }}
+      />
+
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <button
           onClick={() => onTabChange('tasks')}

--- a/src/pages/dashboard/planning/TasksTab.tsx
+++ b/src/pages/dashboard/planning/TasksTab.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
-import { Plus, Edit2, Trash2, CheckSquare, Square, Columns, List, Sparkles, X } from 'lucide-react';
+import { Plus, Edit2, Trash2, CheckSquare, Square, Columns, List, Sparkles } from 'lucide-react';
 import { Card } from '../../../components/ui/Card';
 import { Button } from '../../../components/ui/Button';
 import { Badge } from '../../../components/ui/Badge';
 import { PlanningTask } from './planningService';
 import { formatTaskDueDate, isTaskDueOnOrBefore } from './taskDueDate';
+import { PlanningDecisionCard } from './PlanningDecisionCard';
+import { buildTasksDecisionCard } from './planningDecisionAssistant';
 
 interface Props {
   tasks: PlanningTask[];
@@ -24,12 +26,6 @@ const PRIORITY_COLORS: Record<string, 'error' | 'warning' | 'neutral'> = {
   high: 'error',
   medium: 'warning',
   low: 'neutral',
-};
-
-const STATUS_LABELS: Record<string, string> = {
-  todo: 'To Do',
-  in_progress: 'In Progress',
-  done: 'Done',
 };
 
 function TaskForm({ initial, onSave, onCancel }: {
@@ -223,6 +219,8 @@ export const TasksTab: React.FC<Props> = ({ tasks, weddingDate, onAdd, onUpdate,
     setConfirmCreate(false);
   }
 
+  const taskDecision = buildTasksDecisionCard(tasks);
+
   const kanbanColumns: { status: PlanningTask['status']; label: string }[] = [
     { status: 'todo', label: 'To Do' },
     { status: 'in_progress', label: 'In Progress' },
@@ -231,6 +229,8 @@ export const TasksTab: React.FC<Props> = ({ tasks, weddingDate, onAdd, onUpdate,
 
   return (
     <div className="space-y-4">
+      <PlanningDecisionCard model={taskDecision} />
+
       <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center justify-between">
         <div className="flex items-center gap-2 flex-wrap">
           <select

--- a/src/pages/dashboard/planning/VendorsTab.tsx
+++ b/src/pages/dashboard/planning/VendorsTab.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo, useState } from 'react';
-import { Plus, Edit2, Trash2, Phone, Mail, Globe, AlertTriangle, ChevronDown, ChevronUp } from 'lucide-react';
+import { Plus, Edit2, Trash2, Phone, Mail, Globe, ChevronDown, ChevronUp } from 'lucide-react';
 import { Card } from '../../../components/ui/Card';
 import { Button } from '../../../components/ui/Button';
 import { Badge } from '../../../components/ui/Badge';
 import { PlanningVendor } from './planningService';
 import { formatVendorDate, isVendorDateOnOrBefore } from './vendorDate';
+import { PlanningDecisionCard } from './PlanningDecisionCard';
+import { buildVendorsDecisionCard } from './planningDecisionAssistant';
 
 interface Props {
   vendors: PlanningVendor[];
@@ -179,11 +181,17 @@ export const VendorsTab: React.FC<Props> = ({ vendors, onAdd, onUpdate, onDelete
     try {
       const raw = localStorage.getItem('dayof.vendor.meta.v1');
       if (raw) setVendorMeta(JSON.parse(raw));
-    } catch {}
+    } catch {
+      // Ignore malformed local state and fall back to a clean vendor meta map.
+    }
   }, []);
 
   React.useEffect(() => {
-    try { localStorage.setItem('dayof.vendor.meta.v1', JSON.stringify(vendorMeta)); } catch {}
+    try {
+      localStorage.setItem('dayof.vendor.meta.v1', JSON.stringify(vendorMeta));
+    } catch {
+      // Ignore storage write failures for optional vendor follow-up metadata.
+    }
   }, [vendorMeta]);
 
   const today = new Date();
@@ -219,9 +227,12 @@ export const VendorsTab: React.FC<Props> = ({ vendors, onAdd, onUpdate, onDelete
     'open-balance': filteredVendors.filter((v) => vendorStage(v) === 'open-balance'),
     paid: filteredVendors.filter((v) => vendorStage(v) === 'paid'),
   };
+  const vendorDecision = buildVendorsDecisionCard(vendors);
 
   return (
     <div className="space-y-4">
+      <PlanningDecisionCard model={vendorDecision} />
+
       {(totalBalance > 0 || followUpDueCount > 0) && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
           <div className="flex items-center justify-between p-3 bg-white rounded-xl border border-border/35 shadow-[0_4px_14px_rgba(15,23,42,0.05)] hover:shadow-[0_8px_20px_rgba(15,23,42,0.08)] transition-shadow">

--- a/src/pages/dashboard/planning/planningDecisionAssistant.test.ts
+++ b/src/pages/dashboard/planning/planningDecisionAssistant.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildBudgetDecisionCard,
+  buildPlanningOverviewDecisionCard,
+  buildTasksDecisionCard,
+  buildVendorsDecisionCard,
+} from './planningDecisionAssistant';
+import type { PlanningBudgetItem, PlanningTask, PlanningVendor } from './planningService';
+
+const baseTask: PlanningTask = {
+  id: 'task-1',
+  wedding_site_id: 'site-1',
+  title: 'Confirm rental counts',
+  description: '',
+  due_date: null,
+  status: 'todo',
+  priority: 'medium',
+  owner_name: '',
+  linked_event_id: null,
+  linked_vendor_id: null,
+  sort_order: 0,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const baseBudgetItem: PlanningBudgetItem = {
+  id: 'budget-1',
+  wedding_site_id: 'site-1',
+  category: 'Venue',
+  item_name: 'Venue final payment',
+  estimated_amount: 4000,
+  actual_amount: 3000,
+  paid_amount: 2000,
+  due_date: null,
+  vendor_id: null,
+  notes: '',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const baseVendor: PlanningVendor = {
+  id: 'vendor-1',
+  wedding_site_id: 'site-1',
+  vendor_type: 'Venue',
+  name: 'Garden Hall',
+  contact_name: 'Morgan',
+  email: 'team@gardenhall.com',
+  phone: '555-111-2222',
+  website: '',
+  contract_total: 6000,
+  amount_paid: 3000,
+  balance_due: 3000,
+  next_payment_due: null,
+  notes: '',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+describe('planningDecisionAssistant', () => {
+  it('prioritizes overdue task cleanup in the overview model', () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const model = buildPlanningOverviewDecisionCard({
+      tasks: [{ ...baseTask, due_date: yesterday.toISOString().slice(0, 10), priority: 'high' }],
+      budgetItems: [],
+      vendors: [],
+      seatingReadiness: { attending: 10, seated: 7, unassigned: 3 },
+    });
+
+    expect(model.title).toMatch(/Clear the overdue work first/i);
+    expect(model.primaryAction?.target).toBe('tasks');
+    expect(model.secondaryAction?.target).toBe('seating');
+  });
+
+  it('surfaces category drift in the budget model before generic calm copy', () => {
+    const model = buildBudgetDecisionCard([
+      { ...baseBudgetItem, category: 'Venue', estimated_amount: 4000, actual_amount: 4700 },
+      { ...baseBudgetItem, id: 'budget-2', category: 'Florals & Decor', estimated_amount: 1500, actual_amount: 1800 },
+    ], 10000);
+
+    expect(model.title).toMatch(/A few categories need a second pass/i);
+    expect(model.detail).toMatch(/Venue/i);
+    expect(model.detail).toMatch(/Florals/i);
+  });
+
+  it('keeps the vendor model focused on missing contact truth when money is not urgent', () => {
+    const model = buildVendorsDecisionCard([
+      { ...baseVendor, id: 'vendor-1', balance_due: 0, email: '', phone: '' },
+      { ...baseVendor, id: 'vendor-2', balance_due: 0, email: '', phone: '' },
+    ]);
+
+    expect(model.title).toMatch(/still need cleaner contact details/i);
+    expect(model.badges[0]).toMatch(/2 missing direct contact/i);
+  });
+
+  it('keeps the tasks model focused on weekly high-priority work when nothing is overdue', () => {
+    const inThreeDays = new Date();
+    inThreeDays.setDate(inThreeDays.getDate() + 3);
+
+    const model = buildTasksDecisionCard([
+      { ...baseTask, id: 'task-1', due_date: inThreeDays.toISOString().slice(0, 10), priority: 'high' },
+      { ...baseTask, id: 'task-2', status: 'in_progress' },
+    ]);
+
+    expect(model.title).toMatch(/High-priority work needs a short weekly pass/i);
+    expect(model.badges[0]).toMatch(/1 high-priority due soon/i);
+  });
+});

--- a/src/pages/dashboard/planning/planningDecisionAssistant.ts
+++ b/src/pages/dashboard/planning/planningDecisionAssistant.ts
@@ -1,0 +1,247 @@
+import type { PlanningTask, PlanningBudgetItem, PlanningVendor } from './planningService';
+import { isTaskDueBetween, isTaskDueOnOrBefore } from './taskDueDate';
+import { isVendorDateBetween } from './vendorDate';
+
+export interface PlanningDecisionAction {
+  label: string;
+  target: 'overview' | 'tasks' | 'budget' | 'vendors' | 'seating';
+}
+
+export interface PlanningDecisionCardModel {
+  eyebrow: string;
+  title: string;
+  detail: string;
+  badges: string[];
+  primaryAction?: PlanningDecisionAction;
+  secondaryAction?: PlanningDecisionAction;
+}
+
+interface SeatingReadiness {
+  attending: number;
+  seated: number;
+  unassigned: number;
+}
+
+function dueWindows() {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const in7Days = new Date(today);
+  in7Days.setDate(in7Days.getDate() + 7);
+  return { today, in7Days };
+}
+
+function currency(n: number) {
+  return n.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  });
+}
+
+export function buildPlanningOverviewDecisionCard(args: {
+  tasks: PlanningTask[];
+  budgetItems: PlanningBudgetItem[];
+  vendors: PlanningVendor[];
+  seatingReadiness: SeatingReadiness;
+}): PlanningDecisionCardModel {
+  const { tasks, budgetItems, vendors, seatingReadiness } = args;
+  const { today, in7Days } = dueWindows();
+  const overdueTasks = tasks.filter((task) => task.status !== 'done' && isTaskDueOnOrBefore(task.due_date, today));
+  const dueSoonVendors = vendors.filter((vendor) => vendor.balance_due > 0 && isVendorDateBetween(vendor.next_payment_due, today, in7Days));
+  const totalEstimated = budgetItems.reduce((sum, item) => sum + (item.estimated_amount || 0), 0);
+  const totalActual = budgetItems.reduce((sum, item) => sum + (item.actual_amount || 0), 0);
+  const overBudget = totalEstimated > 0 && totalActual > totalEstimated;
+
+  if (overdueTasks.length > 0) {
+    return {
+      eyebrow: 'Planning assistant',
+      title: 'Clear the overdue work first',
+      detail: `${overdueTasks.length} planning task${overdueTasks.length === 1 ? ' is' : 's are'} already past due. The fastest way to calm the board is to close or reschedule the work that is already slipping.`,
+      badges: [
+        `${overdueTasks.length} overdue`,
+        `${tasks.filter((task) => task.priority === 'high' && task.status !== 'done').length} high priority still open`,
+      ],
+      primaryAction: { label: 'Open tasks', target: 'tasks' },
+      secondaryAction: seatingReadiness.unassigned > 0 ? { label: 'Check seating', target: 'seating' } : undefined,
+    };
+  }
+
+  if (dueSoonVendors.length > 0) {
+    return {
+      eyebrow: 'Planning assistant',
+      title: 'Vendor money is the next pressure point',
+      detail: `${dueSoonVendors.length} vendor payment${dueSoonVendors.length === 1 ? ' is' : 's are'} coming up within a week. Confirm who is due next before the timeline gets crowded.`,
+      badges: [
+        `${currency(dueSoonVendors.reduce((sum, vendor) => sum + (vendor.balance_due || 0), 0))} due soon`,
+        `${vendors.filter((vendor) => (vendor.balance_due || 0) > 0).length} vendors still open`,
+      ],
+      primaryAction: { label: 'Review vendors', target: 'vendors' },
+      secondaryAction: overBudget ? { label: 'Check budget', target: 'budget' } : undefined,
+    };
+  }
+
+  if (overBudget) {
+    return {
+      eyebrow: 'Planning assistant',
+      title: 'Budget drift is the next thing to steady',
+      detail: `Actual spend is ahead of plan by ${currency(totalActual - totalEstimated)}. A quick review of category overages will keep the rest of the board honest.`,
+      badges: [
+        `${currency(totalActual)} spent`,
+        `${currency(Math.max(totalActual - totalEstimated, 0))} over plan`,
+      ],
+      primaryAction: { label: 'Review budget', target: 'budget' },
+      secondaryAction: seatingReadiness.unassigned > 0 ? { label: 'Check seating', target: 'seating' } : undefined,
+    };
+  }
+
+  if (seatingReadiness.unassigned > 0) {
+    return {
+      eyebrow: 'Planning assistant',
+      title: 'Seating is the next place to finish the loop',
+      detail: `${seatingReadiness.unassigned} attending guest${seatingReadiness.unassigned === 1 ? ' is' : 's are'} still unassigned. The rest of the plan is calmer once every confirmed guest has a place.`,
+      badges: [
+        `${seatingReadiness.seated}/${seatingReadiness.attending} seated`,
+        `${tasks.filter((task) => task.status === 'in_progress').length} tasks in progress`,
+      ],
+      primaryAction: { label: 'Open seating', target: 'seating' },
+      secondaryAction: { label: 'Open tasks', target: 'tasks' },
+    };
+  }
+
+  return {
+    eyebrow: 'Planning assistant',
+    title: 'The board is calm enough to polish',
+    detail: 'Nothing is obviously on fire. This is the moment to tighten wording, follow-ups, and small planning edges before they turn into deadline work.',
+    badges: [
+      `${tasks.filter((task) => task.status !== 'done').length} tasks still open`,
+      `${vendors.filter((vendor) => (vendor.balance_due || 0) === 0).length} vendors fully paid`,
+    ],
+    primaryAction: { label: 'Review tasks', target: 'tasks' },
+  };
+}
+
+export function buildTasksDecisionCard(tasks: PlanningTask[]): PlanningDecisionCardModel {
+  const { today, in7Days } = dueWindows();
+  const overdueTasks = tasks.filter((task) => task.status !== 'done' && isTaskDueOnOrBefore(task.due_date, today));
+  const dueSoonHighPriority = tasks.filter((task) => task.status !== 'done' && task.priority === 'high' && isTaskDueBetween(task.due_date, today, in7Days));
+  const inProgressCount = tasks.filter((task) => task.status === 'in_progress').length;
+
+  if (overdueTasks.length > 0) {
+    return {
+      eyebrow: 'Task coach',
+      title: 'Resolve the overdue tasks before you add more',
+      detail: `${overdueTasks.length} task${overdueTasks.length === 1 ? ' is' : 's are'} already late. Finish, delegate, or reschedule those first so the task list stays trustworthy.`,
+      badges: [
+        `${overdueTasks.length} overdue`,
+        `${dueSoonHighPriority.length} high-priority due this week`,
+      ],
+    };
+  }
+
+  if (dueSoonHighPriority.length > 0) {
+    return {
+      eyebrow: 'Task coach',
+      title: 'High-priority work needs a short weekly pass',
+      detail: `${dueSoonHighPriority.length} high-priority task${dueSoonHighPriority.length === 1 ? ' is' : 's are'} due within a week. This is the right moment to tighten owners and dates.`,
+      badges: [
+        `${dueSoonHighPriority.length} high-priority due soon`,
+        `${inProgressCount} already in progress`,
+      ],
+    };
+  }
+
+  return {
+    eyebrow: 'Task coach',
+    title: 'Use this list to keep momentum visible',
+    detail: 'The task board looks stable. Use it to keep ownership clear and turn vague planning work into a small set of real next steps.',
+    badges: [
+      `${tasks.filter((task) => task.status !== 'done').length} open`,
+      `${inProgressCount} in progress`,
+    ],
+  };
+}
+
+export function buildBudgetDecisionCard(items: PlanningBudgetItem[], totalBudget: number): PlanningDecisionCardModel {
+  const totalEstimated = items.reduce((sum, item) => sum + (item.estimated_amount || 0), 0);
+  const totalActual = items.reduce((sum, item) => sum + (item.actual_amount || 0), 0);
+  const remaining = totalBudget - totalActual;
+  const overBudgetCategories = Array.from(new Set(items
+    .filter((item) => item.actual_amount > item.estimated_amount && item.estimated_amount > 0)
+    .map((item) => item.category)))
+    .filter(Boolean);
+
+  if (totalBudget > 0 && totalActual > totalBudget) {
+    return {
+      eyebrow: 'Budget coach',
+      title: 'The actual spend already passed the goal',
+      detail: `You are over the budget goal by ${currency(totalActual - totalBudget)}. Review the categories that drifted first, then decide what still needs real money.`,
+      badges: [
+        `${currency(totalActual)} spent`,
+        `${currency(Math.max(totalActual - totalBudget, 0))} over goal`,
+      ],
+    };
+  }
+
+  if (overBudgetCategories.length > 0) {
+    return {
+      eyebrow: 'Budget coach',
+      title: 'A few categories need a second pass',
+      detail: `The biggest drift is showing up in ${overBudgetCategories.slice(0, 3).join(', ')}${overBudgetCategories.length > 3 ? ', and other categories' : ''}. Tightening those is more useful than staring at the grand total.`,
+      badges: [
+        `${overBudgetCategories.length} categories over estimate`,
+        `${currency(remaining)} remaining`,
+      ],
+    };
+  }
+
+  return {
+    eyebrow: 'Budget coach',
+    title: 'The budget is steady enough to guide decisions',
+    detail: 'Use this view to decide what still needs money, not just to log receipts. When the goal and the actuals stay close, the rest of the plan gets easier.',
+    badges: [
+      `${currency(totalEstimated)} estimated`,
+      `${currency(remaining)} remaining`,
+    ],
+  };
+}
+
+export function buildVendorsDecisionCard(vendors: PlanningVendor[]): PlanningDecisionCardModel {
+  const { today, in7Days } = dueWindows();
+  const dueSoonVendors = vendors.filter((vendor) => vendor.balance_due > 0 && isVendorDateBetween(vendor.next_payment_due, today, in7Days));
+  const openBalanceCount = vendors.filter((vendor) => (vendor.balance_due || 0) > 0).length;
+  const missingContactCount = vendors.filter((vendor) => !vendor.email && !vendor.phone).length;
+
+  if (dueSoonVendors.length > 0) {
+    return {
+      eyebrow: 'Vendor coach',
+      title: 'The next vendor follow-up is about timing, not research',
+      detail: `${dueSoonVendors.length} vendor payment${dueSoonVendors.length === 1 ? ' is' : 's are'} due inside a week. This is the right time to confirm who needs attention next.`,
+      badges: [
+        `${currency(dueSoonVendors.reduce((sum, vendor) => sum + (vendor.balance_due || 0), 0))} due soon`,
+        `${openBalanceCount} vendors still open`,
+      ],
+    };
+  }
+
+  if (missingContactCount > 0) {
+    return {
+      eyebrow: 'Vendor coach',
+      title: 'A few vendors still need cleaner contact details',
+      detail: `${missingContactCount} vendor record${missingContactCount === 1 ? ' is' : 's are'} missing both phone and email. Tightening that up now will matter more than adding more notes later.`,
+      badges: [
+        `${missingContactCount} missing direct contact`,
+        `${openBalanceCount} still carrying balance`,
+      ],
+    };
+  }
+
+  return {
+    eyebrow: 'Vendor coach',
+    title: 'Vendor tracking is steady enough to maintain',
+    detail: 'The vendor list looks calm. Keep contact details, payment timing, and follow-up notes current so this stays a control surface instead of becoming archaeology.',
+    badges: [
+      `${openBalanceCount} open balances`,
+      `${vendors.length} total vendors`,
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared planning decision assistant that spots overdue work, vendor timing pressure, budget drift, and seating readiness
- add a compact advisor card and wire it into planning overview, tasks, budget, and vendors
- keep the planning surface calm while making the next best move much clearer

## Verification
- npm test -- --run src/pages/dashboard/planning/planningDecisionAssistant.test.ts src/pages/dashboard/planning/PlanningOverviewTab.test.tsx
- npx eslint src/pages/dashboard/planning/planningDecisionAssistant.ts src/pages/dashboard/planning/PlanningDecisionCard.tsx src/pages/dashboard/planning/planningDecisionAssistant.test.ts src/pages/dashboard/planning/PlanningOverviewTab.tsx src/pages/dashboard/planning/TasksTab.tsx src/pages/dashboard/planning/BudgetTab.tsx src/pages/dashboard/planning/VendorsTab.tsx
- npm run build
- git diff --check
