### PR TITLE
Add a memory curator across photos and vaults

### DIFF
--- a/src/components/dashboard/MemoryCuratorCard.tsx
+++ b/src/components/dashboard/MemoryCuratorCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Sparkles } from 'lucide-react';
+import { Card } from '../ui/Card';
+import type { MemoryCuratorModel } from '../../lib/memoryCurator';
+
+interface Props {
+  model: MemoryCuratorModel;
+}
+
+export const MemoryCuratorCard: React.FC<Props> = ({ model }) => {
+  return (
+    <Card className="border-rose-200 bg-rose-50/70 p-5">
+      <div className="flex items-start gap-3">
+        <div className="rounded-2xl bg-rose-100 p-2.5">
+          <Sparkles className="h-5 w-5 text-rose-600" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-700/80">{model.eyebrow}</p>
+          <h2 className="mt-1 text-lg font-semibold text-neutral-950">{model.title}</h2>
+          <p className="mt-2 text-sm leading-6 text-neutral-700">{model.detail}</p>
+          {model.badges.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-neutral-600">
+              {model.badges.map((badge) => (
+                <span key={badge} className="rounded-full bg-white px-2.5 py-1 shadow-sm">
+                  {badge}
+                </span>
+              ))}
+            </div>
+          )}
+          {model.nextMoves.length > 0 && (
+            <div className="mt-4 rounded-2xl border border-white/70 bg-white/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-500">Next best moves</p>
+              <ul className="mt-2 space-y-2 text-sm text-neutral-700">
+                {model.nextMoves.map((move) => (
+                  <li key={move} className="flex gap-2">
+                    <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-rose-500" />
+                    <span>{move}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/src/components/dashboard/PhotoBucketCards.test.tsx
+++ b/src/components/dashboard/PhotoBucketCards.test.tsx
@@ -8,5 +8,15 @@ describe('PhotoBucketCards', () => {
     render(<PhotoBucketCards buckets={createEmptyPhotoBuckets()} />);
     expect(screen.getByText('Main photo of you two')).toBeInTheDocument();
     expect(screen.getByText('Weekend / destination photos')).toBeInTheDocument();
+    expect(screen.getAllByText('Empty').length).toBeGreaterThan(0);
+  });
+
+  it('shows readiness hints when buckets have enough photos', () => {
+    const buckets = createEmptyPhotoBuckets();
+    buckets['main-couple'] = [{ id: 'hero', url: '/hero.jpg', bucket: 'main-couple', label: 'Hero' }];
+
+    render(<PhotoBucketCards buckets={buckets} />);
+
+    expect(screen.getByText('Hero ready')).toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/PhotoBucketCards.tsx
+++ b/src/components/dashboard/PhotoBucketCards.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ImagePlus } from 'lucide-react';
 import { CanonicalPhotoBuckets, PhotoBucketKind } from '../../lib/aiPhotoBuckets';
+import { buildPhotoBucketStatusMap } from '../../lib/memoryCurator';
 
 const BUCKETS: Array<{ key: PhotoBucketKind; title: string; description: string; placementHint: string }> = [
   { key: 'main-couple', title: 'Main photo of you two', description: 'One favorite photo. We use this for the hero by default.', placementHint: 'Usually lands in the hero first.' },
@@ -17,16 +18,28 @@ type Props = {
 };
 
 export const PhotoBucketCards: React.FC<Props> = ({ buckets, onUploadClick, onRemoveClick }) => {
+  const bucketStatusMap = buildPhotoBucketStatusMap(buckets);
+
   return (
     <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
       {BUCKETS.map((bucket) => {
         const items = buckets[bucket.key] ?? [];
+        const status = bucketStatusMap[bucket.key];
+        const chipClass = status.tone === 'ready'
+          ? 'bg-emerald-50 text-emerald-700'
+          : status.tone === 'growing'
+            ? 'bg-amber-50 text-amber-700'
+            : 'bg-neutral-100 text-neutral-600';
         return (
           <div key={bucket.key} className="rounded-3xl border border-border bg-surface p-4 shadow-sm">
             <div className="flex items-start justify-between gap-3">
               <div>
                 <h3 className="text-base font-semibold text-text-primary">{bucket.title}</h3>
                 <p className="mt-1 text-sm text-text-secondary">{bucket.description}</p>
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <span className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${chipClass}`}>{status.label}</span>
+                  <p className="text-xs text-text-tertiary">{status.detail}</p>
+                </div>
                 <p className="mt-2 text-xs text-text-tertiary">{bucket.placementHint}</p>
               </div>
               <span className="rounded-full bg-primary-light px-2.5 py-1 text-xs font-medium text-primary">{items.length}</span>

--- a/src/lib/memoryCurator.test.ts
+++ b/src/lib/memoryCurator.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { createEmptyPhotoBuckets } from './aiPhotoBuckets';
+import {
+  buildPhotoBucketStatusMap,
+  buildPhotoMemoryCuratorModel,
+  buildVaultMemoryCuratorModel,
+} from './memoryCurator';
+
+describe('memoryCurator', () => {
+  it('marks photo buckets as ready once they hit their goal', () => {
+    const buckets = createEmptyPhotoBuckets();
+    buckets['main-couple'] = [
+      { id: 'hero', url: '/hero.jpg', bucket: 'main-couple', label: 'Hero' },
+    ];
+    buckets['couple-gallery'] = [
+      { id: 'cg-1', url: '/1.jpg', bucket: 'couple-gallery' },
+      { id: 'cg-2', url: '/2.jpg', bucket: 'couple-gallery' },
+      { id: 'cg-3', url: '/3.jpg', bucket: 'couple-gallery' },
+      { id: 'cg-4', url: '/4.jpg', bucket: 'couple-gallery' },
+    ];
+
+    const statusMap = buildPhotoBucketStatusMap(buckets);
+
+    expect(statusMap['main-couple'].label).toBe('Hero ready');
+    expect(statusMap['couple-gallery'].label).toBe('Ready to place');
+    expect(statusMap['weekend-vibe'].label).toBe('Empty');
+  });
+
+  it('nudges the photo flow toward a first signature upload when needed', () => {
+    const model = buildPhotoMemoryCuratorModel({
+      photoBuckets: createEmptyPhotoBuckets(),
+      albums: [],
+      uploads: [],
+      isArchiveLike: false,
+    });
+
+    expect(model.title).toContain('Start with the one photo guests should remember first');
+    expect(model.nextMoves[0]).toContain('Main photo of you two');
+  });
+
+  it('nudges the vault toward recap generation once enough entries exist', () => {
+    const model = buildVaultMemoryCuratorModel({
+      configs: [{ id: 'vault-1', duration_years: 1, is_enabled: true }],
+      entries: [
+        { vault_config_id: 'vault-1', title: 'First note', author_name: 'You', attachment_name: null },
+        { vault_config_id: 'vault-1', title: 'Photo note', author_name: 'You', attachment_name: 'dance-floor.jpg', media_type: 'photo' },
+        { vault_config_id: 'vault-1', title: 'Guest memory', author_name: 'Mia', attachment_name: null },
+      ],
+      isArchiveLike: true,
+      driveConnectedHealthy: true,
+    });
+
+    expect(model.title).toContain('first recap');
+    expect(model.nextMoves[0]).toContain('Generate the first AI recap');
+  });
+});

--- a/src/lib/memoryCurator.ts
+++ b/src/lib/memoryCurator.ts
@@ -1,0 +1,295 @@
+import type { CanonicalPhotoBuckets, PhotoBucketKind } from './aiPhotoBuckets';
+
+export interface PhotoAlbumSnapshot {
+  id: string;
+  name: string;
+  is_active: boolean;
+}
+
+export interface PhotoUploadSnapshot {
+  photo_bucket_id: string;
+  is_hidden: boolean;
+  is_flagged: boolean;
+}
+
+export interface VaultConfigSnapshot {
+  id: string;
+  duration_years: number;
+  is_enabled: boolean;
+}
+
+export interface VaultEntrySnapshot {
+  vault_config_id: string | null;
+  title: string;
+  author_name: string;
+  attachment_name: string | null;
+  media_type?: 'text' | 'photo' | 'video' | 'voice' | null;
+}
+
+export interface MemoryCuratorModel {
+  eyebrow: string;
+  title: string;
+  detail: string;
+  badges: string[];
+  nextMoves: string[];
+}
+
+export interface PhotoBucketStatus {
+  tone: 'empty' | 'growing' | 'ready';
+  label: string;
+  detail: string;
+}
+
+const BUCKET_GOALS: Record<PhotoBucketKind, number> = {
+  'main-couple': 1,
+  'couple-gallery': 4,
+  'weekend-vibe': 3,
+  'friends-family': 3,
+  extras: 2,
+};
+
+const countVisiblePhotoUploads = (
+  uploads: PhotoUploadSnapshot[],
+  albumId: string,
+) => uploads.filter((upload) => upload.photo_bucket_id === albumId && !upload.is_hidden).length;
+
+const isGuestVaultAuthor = (authorName: string) => {
+  const normalized = authorName.trim().toLowerCase();
+  return normalized.length > 0 && normalized !== 'you' && normalized !== 'dayof ai recap';
+};
+
+export const buildPhotoBucketStatusMap = (
+  buckets: CanonicalPhotoBuckets,
+): Record<PhotoBucketKind, PhotoBucketStatus> => {
+  return (Object.keys(BUCKET_GOALS) as PhotoBucketKind[]).reduce((acc, bucketKey) => {
+    const count = buckets[bucketKey]?.length ?? 0;
+    const goal = BUCKET_GOALS[bucketKey];
+
+    if (count === 0) {
+      acc[bucketKey] = {
+        tone: 'empty',
+        label: 'Empty',
+        detail: 'Nothing here yet.',
+      };
+      return acc;
+    }
+
+    if (count < goal) {
+      acc[bucketKey] = {
+        tone: 'growing',
+        label: `Need ${goal - count} more`,
+        detail: `${count}/${goal} photos toward a stronger draft.`,
+      };
+      return acc;
+    }
+
+    acc[bucketKey] = {
+      tone: 'ready',
+      label: bucketKey === 'main-couple' ? 'Hero ready' : 'Ready to place',
+      detail: `${count} photos ready for the draft.`,
+    };
+    return acc;
+  }, {} as Record<PhotoBucketKind, PhotoBucketStatus>);
+};
+
+export const buildPhotoMemoryCuratorModel = (args: {
+  photoBuckets: CanonicalPhotoBuckets;
+  albums: PhotoAlbumSnapshot[];
+  uploads: PhotoUploadSnapshot[];
+  isArchiveLike: boolean;
+}): MemoryCuratorModel => {
+  const { photoBuckets, albums, uploads, isArchiveLike } = args;
+  const bucketStatus = buildPhotoBucketStatusMap(photoBuckets);
+  const activeAlbums = albums.filter((album) => album.is_active);
+  const totalVisibleUploads = uploads.filter((upload) => !upload.is_hidden).length;
+  const flaggedUploads = uploads.filter((upload) => upload.is_flagged && !upload.is_hidden).length;
+  const readyAlbums = activeAlbums.filter((album) => countVisiblePhotoUploads(uploads, album.id) >= 3);
+  const signatureReadyCount = ['main-couple', 'couple-gallery'].filter(
+    (bucketKey) => bucketStatus[bucketKey].tone === 'ready',
+  ).length;
+  const atmosphereReadyCount = ['weekend-vibe', 'friends-family', 'extras'].filter(
+    (bucketKey) => bucketStatus[bucketKey].tone === 'ready',
+  ).length;
+
+  if ((photoBuckets['main-couple']?.length ?? 0) === 0) {
+    return {
+      eyebrow: 'Memory curator',
+      title: 'Start with the one photo guests should remember first',
+      detail: 'The system still needs a signature couple photo before it can make the hero feel intentional. Everything else gets easier once that anchor is in place.',
+      badges: [
+        `${signatureReadyCount}/2 signature buckets ready`,
+        `${activeAlbums.length} live upload bucket${activeAlbums.length === 1 ? '' : 's'}`,
+      ],
+      nextMoves: [
+        'Upload one favorite couple portrait into Main photo of you two.',
+        'Add a few more couple photos so the story section has real depth.',
+        'Leave guest upload buckets simple until the couple photos feel settled.',
+      ],
+    };
+  }
+
+  if (activeAlbums.length === 0) {
+    return {
+      eyebrow: 'Memory curator',
+      title: 'Your photos are ready for guests, but the upload path is not live yet',
+      detail: 'The private bucket board has enough direction now. The next step is turning that into one or two clear guest upload moments instead of a long list of options.',
+      badges: [
+        `${signatureReadyCount}/2 signature buckets ready`,
+        `${atmosphereReadyCount}/3 atmosphere buckets started`,
+      ],
+      nextMoves: [
+        'Create the first live bucket for the one moment you care about most.',
+        'Only add more guest buckets when the first one has a clear purpose.',
+        'Keep the upload path obvious: one link, one QR, one expectation.',
+      ],
+    };
+  }
+
+  if (totalVisibleUploads > 0 && readyAlbums.length === 0) {
+    return {
+      eyebrow: 'Memory curator',
+      title: 'You are a few uploads away from a real story loop',
+      detail: 'Guests are sending photos, but no active bucket has enough visible uploads to feel slideshow-ready yet. A little curation now will give the memory flow some shape.',
+      badges: [
+        `${totalVisibleUploads} visible upload${totalVisibleUploads === 1 ? '' : 's'}`,
+        `${flaggedUploads} flagged for review`,
+      ],
+      nextMoves: [
+        'Push one live bucket to at least three strong visible uploads.',
+        'Hide or review the flagged uploads before you export anything.',
+        'Once one bucket feels solid, preview the slideshow before adding more complexity.',
+      ],
+    };
+  }
+
+  if (isArchiveLike && totalVisibleUploads > 0) {
+    return {
+      eyebrow: 'Memory curator',
+      title: 'Collection is working. Now turn it into something worth keeping.',
+      detail: 'The wedding is behind you and the upload flow has enough signal now. This is the moment to preserve the strongest moments in the vault instead of collecting forever.',
+      badges: [
+        `${readyAlbums.length} slideshow-ready bucket${readyAlbums.length === 1 ? '' : 's'}`,
+        `${totalVisibleUploads} visible upload${totalVisibleUploads === 1 ? '' : 's'}`,
+      ],
+      nextMoves: [
+        'Use the strongest bucket to shape a first slideshow or recap draft.',
+        'Move the moments that matter most into the Archive Vaults.',
+        'Keep collecting only if the next bucket adds a genuinely different memory angle.',
+      ],
+    };
+  }
+
+  return {
+    eyebrow: 'Memory curator',
+    title: 'The memory flow is balanced enough to start curating, not just collecting',
+    detail: 'You have the couple anchors, live guest paths, and enough uploads to make this feel intentional. The next wins are about taste and continuity, not more buckets.',
+    badges: [
+      `${readyAlbums.length} slideshow-ready bucket${readyAlbums.length === 1 ? '' : 's'}`,
+      `${signatureReadyCount}/2 signature buckets ready`,
+    ],
+    nextMoves: [
+      'Preview the slideshow while the best moments are still easy to spot.',
+      'Keep one or two guest buckets active instead of opening everything at once.',
+      'When a bucket feels complete, decide whether it belongs in the vault next.',
+    ],
+  };
+};
+
+export const buildVaultMemoryCuratorModel = (args: {
+  configs: VaultConfigSnapshot[];
+  entries: VaultEntrySnapshot[];
+  isArchiveLike: boolean;
+  driveConnectedHealthy: boolean;
+}): MemoryCuratorModel => {
+  const { configs, entries, isArchiveLike, driveConnectedHealthy } = args;
+  const enabledVaults = configs.filter((config) => config.is_enabled);
+  const guestEntries = entries.filter((entry) => isGuestVaultAuthor(entry.author_name));
+  const recapEntries = entries.filter((entry) => (entry.title || '').toLowerCase().includes('ai recap'));
+  const photoEntries = entries.filter((entry) => {
+    const media = (entry.media_type || '').toLowerCase();
+    const file = (entry.attachment_name || '').toLowerCase();
+    return media === 'photo' || /\.(jpg|jpeg|png|webp|heic)$/i.test(file);
+  });
+
+  if (!driveConnectedHealthy) {
+    return {
+      eyebrow: 'Memory curator',
+      title: 'Reconnect Drive before this becomes your long-term memory home',
+      detail: 'The vault only feels trustworthy when storage is healthy. Fix that first so every note, photo, and recap lands somewhere dependable.',
+      badges: [
+        `${enabledVaults.length} enabled vault${enabledVaults.length === 1 ? '' : 's'}`,
+        `${entries.length} saved entr${entries.length === 1 ? 'y' : 'ies'}`,
+      ],
+      nextMoves: [
+        'Reconnect Google Drive so future entries land cleanly.',
+        'Then add or refresh the vault entry you care about most.',
+      ],
+    };
+  }
+
+  if (entries.length === 0) {
+    return {
+      eyebrow: 'Memory curator',
+      title: 'Write the first note before the wedding starts to blur',
+      detail: 'The best first vault entry is not a perfect one. It is the note you write while the feeling is still fresh enough to be honest.',
+      badges: [
+        `${enabledVaults.length} enabled vault${enabledVaults.length === 1 ? '' : 's'}`,
+        `${configs.length} vault milestone${configs.length === 1 ? '' : 's'}`,
+      ],
+      nextMoves: [
+        'Add one short note for your first anniversary.',
+        'Keep the first vault personal before you open anything to guests.',
+        'Once one note exists, decide which future milestone deserves the next one.',
+      ],
+    };
+  }
+
+  if (isArchiveLike && guestEntries.length === 0) {
+    return {
+      eyebrow: 'Memory curator',
+      title: 'The archive exists. Now invite a few meaningful voices into it.',
+      detail: 'Right now the vault reads like a private notebook. That is good, but it gets more powerful once one or two people who matter most add their side of the story.',
+      badges: [
+        `${entries.length} saved entr${entries.length === 1 ? 'y' : 'ies'}`,
+        `${recapEntries.length} recap${recapEntries.length === 1 ? '' : 's'}`,
+      ],
+      nextMoves: [
+        'Share a single vault with the people whose memories you most want back.',
+        'Keep the guest path selective instead of blasting every vault everywhere.',
+        'After guest entries start landing, decide whether the recap should refresh.',
+      ],
+    };
+  }
+
+  if (entries.length >= 3 && recapEntries.length === 0) {
+    return {
+      eyebrow: 'Memory curator',
+      title: 'You have enough material for a first recap',
+      detail: 'The vault is carrying a real story now. A recap will help you turn scattered notes and photos into something you can revisit later without digging through everything.',
+      badges: [
+        `${entries.length} saved entr${entries.length === 1 ? 'y' : 'ies'}`,
+        `${photoEntries.length} photo entr${photoEntries.length === 1 ? 'y' : 'ies'}`,
+      ],
+      nextMoves: [
+        'Generate the first AI recap while the collection is still compact.',
+        'Use photo-first mode if the visual memories are stronger than the written ones.',
+        'Refresh the recap later instead of trying to make it perfect in one pass.',
+      ],
+    };
+  }
+
+  return {
+    eyebrow: 'Memory curator',
+    title: 'The vault is preserving a real shared story now',
+    detail: 'You have enough notes, media, and structure for this to feel like a living archive instead of a hidden feature. The next job is gentle maintenance, not reinvention.',
+    badges: [
+      `${guestEntries.length} guest entr${guestEntries.length === 1 ? 'y' : 'ies'}`,
+      `${recapEntries.length} recap${recapEntries.length === 1 ? '' : 's'} ready`,
+    ],
+    nextMoves: [
+      'Refresh the recap after each meaningful new cluster of entries.',
+      'Keep only the vaults that match real anniversaries you want to celebrate.',
+      'Use the vault as the place memories mature, not the place everything gets dumped.',
+    ],
+  };
+};

--- a/src/pages/dashboard/GuestPhotoSharing.tsx
+++ b/src/pages/dashboard/GuestPhotoSharing.tsx
@@ -15,6 +15,8 @@ import { PhotoBucketKind } from '../../lib/aiPhotoBuckets';
 import { buildPhotoPlacementPlan } from '../../lib/aiPhotoPlacement';
 import { mergeGeneratedDraftIntoBuilderProject } from '../../lib/aiBuilderProjectPatch';
 import { buildQuickStartOverviewPath, readQuickStartDashboardContinuation } from '../../lib/quickStartContinuation';
+import { buildPhotoMemoryCuratorModel } from '../../lib/memoryCurator';
+import { MemoryCuratorCard } from '../../components/dashboard/MemoryCuratorCard';
 import { parseDatetimeLocalToIso, toDatetimeLocalOrEmpty } from './guestPhotoDateTime';
 import { formatGuestPhotoDate, formatGuestPhotoDateTime, getGuestPhotoSortTime, toGuestPhotoCsvTimestamp } from './guestPhotoUploadTime';
 import { formatGuestPhotoEventDate, getSuggestedGuestPhotoWindowStart } from './guestPhotoEventDate';
@@ -93,7 +95,6 @@ export const GuestPhotoSharing: React.FC = () => {
   const [success, setSuccess] = useState<string | null>(null);
 
   const [siteId, setSiteId] = useState<string | null>(null);
-  const [siteSlug, setSiteSlug] = useState<string | null>(null);
   const [events, setEvents] = useState<ItineraryEvent[]>([]);
   const [buckets, setBuckets] = useState<PhotoBucketRow[]>([]);
   const [uploads, setUploads] = useState<PhotoUploadRow[]>([]);
@@ -112,7 +113,6 @@ export const GuestPhotoSharing: React.FC = () => {
 
   const [windowDrafts, setWindowDrafts] = useState<Record<string, { opensAt: string; closesAt: string }>>({});
   const [bulkCreating, setBulkCreating] = useState(false);
-  const [bulkUpdatingStatus, setBulkUpdatingStatus] = useState(false);
   const [bulkRegenerating, setBulkRegenerating] = useState(false);
   const [bulkModerating, setBulkModerating] = useState(false);
   const [photoBuckets, setPhotoBuckets] = useState(() => createEmptyPhotoBuckets());
@@ -123,6 +123,16 @@ export const GuestPhotoSharing: React.FC = () => {
   const bucketFileInputRef = useRef<HTMLInputElement | null>(null);
   const [pendingBucket, setPendingBucket] = useState<PhotoBucketKind | null>(null);
   const archiveMode = useMemo(() => getArchiveModeDescriptor({ weddingDate: events[0]?.event_date ?? null }), [events]);
+  const photoMemoryCurator = useMemo(() => buildPhotoMemoryCuratorModel({
+    photoBuckets,
+    albums: buckets.map((bucket) => ({ id: bucket.id, name: bucket.name, is_active: bucket.is_active })),
+    uploads: uploads.map((upload) => ({
+      photo_bucket_id: upload.photo_bucket_id,
+      is_hidden: upload.is_hidden,
+      is_flagged: upload.is_flagged,
+    })),
+    isArchiveLike: archiveMode.isArchiveLike,
+  }), [archiveMode.isArchiveLike, buckets, photoBuckets, uploads]);
 
   useEffect(() => {
     void load();
@@ -263,7 +273,6 @@ export const GuestPhotoSharing: React.FC = () => {
       if (siteErr || !site) throw new Error(siteErr?.message ?? 'No wedding site found.');
 
       setSiteId(site.id as string);
-      setSiteSlug((site.site_slug as string) ?? null);
       const savedBuckets = ((((site.wedding_data as Record<string, unknown> | null)?.meta as Record<string, unknown> | undefined)?.photoBuckets as ReturnType<typeof createEmptyPhotoBuckets> | undefined) ?? null);
       if (savedBuckets) setPhotoBuckets(savedBuckets);
 
@@ -320,7 +329,6 @@ export const GuestPhotoSharing: React.FC = () => {
         return;
       }
       setSiteId(null);
-      setSiteSlug(null);
       setEvents([]);
       setBuckets([]);
       setUploads([]);
@@ -397,7 +405,13 @@ export const GuestPhotoSharing: React.FC = () => {
       selectedUploads = [...selectedUploads].sort((a, b) => a.uploadId.localeCompare(b.uploadId));
     }
 
-    return selectedUploads.slice(0, 24).map(({ uploadedAt: _uploadedAt, ...frame }) => frame);
+    return selectedUploads.slice(0, 24).map((frame) => ({
+      uploadId: frame.uploadId,
+      bucketId: frame.bucketId,
+      bucketName: frame.bucketName,
+      title: frame.title,
+      caption: frame.caption,
+    }));
   }, [buckets, uploads, countsByBucket, slideshowBucketFilter, slideshowOrder]);
 
   const slideshowThemeMeta: Record<SlideshowTheme, { label: string; cardClass: string; chipClass: string; helper: string }> = {
@@ -739,31 +753,6 @@ export const GuestPhotoSharing: React.FC = () => {
     }
   };
 
-  const setAllBucketsActive = async (isActive: boolean) => {
-    const targetBuckets = buckets.filter((a) => a.is_active !== isActive);
-    if (targetBuckets.length === 0) {
-      setSuccess(isActive ? 'All buckets are already active.' : 'All buckets are already paused.');
-      return;
-    }
-
-    try {
-      setBulkUpdatingStatus(true);
-      setError(null);
-      setSuccess(null);
-
-      for (const bucket of targetBuckets) {
-        await invokeOrThrow('photo-album-manage', { action: 'set_active', albumId: bucket.id, isActive });
-      }
-
-      await load();
-      setSuccess(`${isActive ? 'Activated' : 'Paused'} ${targetBuckets.length} bucket(s).`);
-    } catch (err: unknown) {
-      setError((err as Error)?.message || 'Failed to update bucket statuses.');
-    } finally {
-      setBulkUpdatingStatus(false);
-    }
-  };
-
   const moderateUpload = async (uploadId: string, patch: Partial<Pick<PhotoUploadRow, 'is_hidden' | 'is_flagged'>>) => {
     try {
       setError(null);
@@ -928,6 +917,8 @@ export const GuestPhotoSharing: React.FC = () => {
             </div>
           </div>
         </div>
+
+        <MemoryCuratorCard model={photoMemoryCurator} />
 
         <Card className="border-0 bg-neutral-950 text-white shadow-sm">
           <div className="flex flex-col gap-4 p-6 lg:flex-row lg:items-center lg:justify-between">

--- a/src/pages/dashboard/Vault.tsx
+++ b/src/pages/dashboard/Vault.tsx
@@ -5,15 +5,17 @@ import { Card, Button } from '../../components/ui';
 import {
   Lock, Unlock, Plus, Trash2, ChevronDown, ChevronUp, Loader2,
   AlertCircle, Paperclip, Link2, Check, Settings2, ToggleLeft,
-  ToggleRight, GripVertical, X, Sparkles
+  ToggleRight, GripVertical, X
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { resolveActiveSiteForUser } from '../../lib/activeSite';
 import { useAuth } from '../../hooks/useAuth';
 import { getArchiveModeDescriptor } from '../../lib/archiveMode';
 import { sendAnniversaryReminder } from '../../lib/emailService';
+import { buildVaultMemoryCuratorModel } from '../../lib/memoryCurator';
+import { MemoryCuratorCard } from '../../components/dashboard/MemoryCuratorCard';
 import { formatVaultUnlockDate, getVaultUnlockDate, toValidDateOrNull } from './vaultDate';
-import { formatVaultEntryDate, getVaultEntryTimestamp } from './vaultEntryTime';
+import { formatVaultEntryDate } from './vaultEntryTime';
 
 const MAX_VAULTS = 5;
 const DEMO_VAULT_STORAGE_KEY = 'dayof_demo_vault_state_v1';
@@ -231,98 +233,6 @@ interface VaultCardProps {
   onEdit: (config: VaultConfig) => void;
 }
 
-function buildAnniversaryRecap(
-  entries: VaultEntry[],
-  years: number,
-  style: 'classic' | 'playful' | 'cinematic' = 'classic',
-  length: 'short' | 'medium' | 'long' = 'medium',
-  photosOnly = false,
-): string {
-  const source = photosOnly
-    ? entries.filter((e) => {
-        const media = (e.media_type || '').toLowerCase();
-        const file = (e.attachment_name || '').toLowerCase();
-        return media === 'photo' || /\.(jpg|jpeg|png|webp|heic)$/i.test(file);
-      })
-    : entries;
-
-  const sorted = [...source].sort((a, b) => getVaultEntryTimestamp(a.created_at) - getVaultEntryTimestamp(b.created_at));
-  const first = sorted[0];
-  const last = sorted[sorted.length - 1];
-
-  const photoEntries = sorted.filter((e) => {
-    const media = (e.media_type || '').toLowerCase();
-    const file = (e.attachment_name || '').toLowerCase();
-    return media === 'photo' || /\.(jpg|jpeg|png|webp|heic)$/i.test(file);
-  });
-
-  const timelineLimit = length === 'short' ? 5 : length === 'long' ? 14 : 10;
-  const photoLimit = length === 'short' ? 4 : length === 'long' ? 10 : 8;
-
-  const timelineMoments = sorted.slice(0, timelineLimit).map((entry) => {
-    const date = formatVaultEntryDate(entry.created_at);
-    const title = (entry.title || '').trim();
-    const fileName = (entry.attachment_name || '').trim();
-    const content = (entry.content || '').trim();
-
-    const core = title || content || fileName || 'A shared memory';
-    const cleanCore = core.length > 120 ? `${core.slice(0, 117)}…` : core;
-    return `- ${date}: ${cleanCore}`;
-  });
-
-  const photoHighlights = photoEntries.slice(0, photoLimit).map((entry) => {
-    const date = formatVaultEntryDate(entry.created_at, { month: 'short', year: 'numeric' });
-    const name = (entry.attachment_name || entry.title || 'Captured moment').replace(/[_-]+/g, ' ').trim();
-    return `- ${date}: ${name}`;
-  });
-
-  const textCorpus = sorted.map((e) => `${e.title || ''} ${e.content || ''} ${e.attachment_name || ''}`.toLowerCase()).join(' ');
-  const themes = [
-    'family', 'friends', 'dance', 'ceremony', 'sunset', 'travel', 'laughter', 'home', 'joy', 'gratitude'
-  ].filter((w) => textCorpus.includes(w)).slice(0, 4);
-
-  const openingDate = first ? formatVaultEntryDate(first.created_at, { month: 'long', year: 'numeric' }, '') : null;
-  const closingDate = last ? formatVaultEntryDate(last.created_at, { month: 'long', year: 'numeric' }, '') : null;
-
-  const openingBase = openingDate && closingDate
-    ? `Over ${openingDate} to ${closingDate}, this ${years}-year chapter unfolds through ${sorted.length} saved memories, including ${photoEntries.length} photo moments.`
-    : `This ${years}-year chapter unfolds through ${sorted.length} saved memories, including ${photoEntries.length} photo moments.`;
-
-  const themeLine = themes.length > 0
-    ? `The strongest threads are ${themes.join(', ')} — a story of presence, warmth, and shared celebration.`
-    : 'The strongest thread is closeness — the kind of love that shows up in small moments and big celebrations alike.';
-
-  const styleOpen = style === 'cinematic'
-    ? `${openingBase} It feels like a film told in frames, glances, and quiet gestures.`
-    : style === 'playful'
-    ? `${openingBase} It’s full of energy, laughter, and beautifully chaotic joy.`
-    : openingBase;
-
-  const closing = style === 'cinematic'
-    ? 'Looking back, these memories feel like scenes from a beautiful film: vivid, intimate, and timeless.'
-    : style === 'playful'
-    ? 'Looking back, this chapter is pure heart: big laughs, happy tears, and the kind of love that keeps getting better.'
-    : 'Looking back, these memories read like a promise kept: to keep choosing each other, to keep celebrating together, and to keep building a life full of meaning.';
-
-  return [
-    `${years}-Year Anniversary Recap (${style[0].toUpperCase()}${style.slice(1)})`,
-    photosOnly ? 'Photo-first mode enabled' : 'Mixed memories mode',
-    '',
-    styleOpen,
-    themeLine,
-    '',
-    'Story arc',
-    ...timelineMoments,
-    '',
-    photoHighlights.length > 0 ? 'Photo highlights' : 'Highlight moments',
-    ...(photoHighlights.length > 0 ? photoHighlights : timelineMoments.slice(0, 5)),
-    '',
-    closing,
-    '',
-    '— AI recap draft (editable)'
-  ].join('\n');
-}
-
 const VaultCard: React.FC<VaultCardProps> = ({
   config, entries, weddingDate, siteSlug, showForm,
   onAddEntry, onDeleteEntry, onSaveEntry, onCancelForm, onToggleEnabled, onEdit
@@ -330,17 +240,10 @@ const VaultCard: React.FC<VaultCardProps> = ({
   const [expanded, setExpanded] = useState(true);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [recapCopied, setRecapCopied] = useState(false);
   const [toggling, setToggling] = useState(false);
-  const [generatingRecap, setGeneratingRecap] = useState(false);
-  const [recapStyle, setRecapStyle] = useState<'classic' | 'playful' | 'cinematic'>('classic');
-  const [recapLength, setRecapLength] = useState<'short' | 'medium' | 'long'>('medium');
-  const [photosOnlyRecap, setPhotosOnlyRecap] = useState(true);
   const [resolvedEntryLinks, setResolvedEntryLinks] = useState<Record<string, string>>({});
   const [resolvingEntryId, setResolvingEntryId] = useState<string | null>(null);
-  const [entryOverrides, setEntryOverrides] = useState<Record<string, Partial<VaultEntry>>>({});
-
-  const displayEntries = entries.map((entry) => ({ ...entry, ...(entryOverrides[entry.id] ?? {}) }));
+  const displayEntries = entries;
 
   const unlockDate = getVaultUnlockDate(weddingDate, config.duration_years);
   const isUnlocked = unlockDate ? new Date() >= unlockDate : false;
@@ -413,81 +316,6 @@ const VaultCard: React.FC<VaultCardProps> = ({
     } finally {
       setToggling(false);
     }
-  }
-
-  async function handleGenerateRecap() {
-    if (displayEntries.length === 0 || generatingRecap) return;
-    setGeneratingRecap(true);
-    try {
-      await onSaveEntry({
-        vault_config_id: config.id,
-        vault_year: config.duration_years,
-        title: `${config.duration_years}-Year AI Recap`,
-        content: buildAnniversaryRecap(displayEntries, config.duration_years, recapStyle, recapLength, photosOnlyRecap),
-        author_name: 'DayOf AI Recap',
-        attachment_url: null,
-        attachment_name: null,
-      });
-    } finally {
-      setGeneratingRecap(false);
-    }
-  }
-
-  async function handleRegenerateLatestRecap() {
-    if (generatingRecap) return;
-    const latestRecap = [...displayEntries]
-      .filter((entry) => (entry.title || '').toLowerCase().includes('ai recap'))
-      .sort((a, b) => getVaultEntryTimestamp(b.created_at) - getVaultEntryTimestamp(a.created_at))[0];
-
-    if (!latestRecap) {
-      await handleGenerateRecap();
-      return;
-    }
-
-    setGeneratingRecap(true);
-    try {
-      const nextContent = buildAnniversaryRecap(displayEntries, config.duration_years, recapStyle, recapLength, photosOnlyRecap);
-      const nextTitle = `${config.duration_years}-Year AI Recap (${recapStyle[0].toUpperCase()}${recapStyle.slice(1)})`;
-      const { error } = await supabase
-        .from('vault_entries')
-        .update({
-          title: nextTitle,
-          content: nextContent,
-          author_name: 'DayOf AI Recap',
-        })
-        .eq('id', latestRecap.id);
-      if (error) throw error;
-      setEntryOverrides((prev) => ({
-        ...prev,
-        [latestRecap.id]: {
-          ...prev[latestRecap.id],
-          title: nextTitle,
-          content: nextContent,
-          author_name: 'DayOf AI Recap',
-        },
-      }));
-    } catch (err) {
-      window.alert(err instanceof Error ? err.message : 'Could not refresh the AI recap.');
-    } finally {
-      setGeneratingRecap(false);
-    }
-  }
-
-  const latestRecap = [...displayEntries]
-    .filter((entry) => (entry.title || '').toLowerCase().includes('ai recap'))
-    .sort((a, b) => getVaultEntryTimestamp(b.created_at) - getVaultEntryTimestamp(a.created_at))[0];
-  const hasRecap = !!latestRecap;
-
-  function handleCopyRecapLink() {
-    const base = buildVaultShareUrl();
-    if (!base || !latestRecap) return;
-    const url = `${base}?entry=${latestRecap.id}`;
-    navigator.clipboard.writeText(url).then(() => {
-      setRecapCopied(true);
-      setTimeout(() => setRecapCopied(false), 2000);
-    }).catch(() => {
-      window.prompt('Copy this recap link:', url);
-    });
   }
 
   return (
@@ -855,10 +683,10 @@ export const DashboardVault: React.FC = () => {
   const [editingConfig, setEditingConfig] = useState<VaultConfig | null>(null);
   const [addingVault, setAddingVault] = useState(false);
   const [toasts, setToasts] = useState<Toast[]>([]);
-  const [vaultStorageProvider, setVaultStorageProvider] = useState<'supabase' | 'google_drive'>('supabase');
+  const [, setVaultStorageProvider] = useState<'supabase' | 'google_drive'>('supabase');
   const [googleDriveConnected, setGoogleDriveConnected] = useState(false);
   const [connectingDrive, setConnectingDrive] = useState(false);
-  const [driveHealthChecking, setDriveHealthChecking] = useState(false);
+  const [, setDriveHealthChecking] = useState(false);
   const [driveHealthMessage, setDriveHealthMessage] = useState<string | null>(null);
   const [driveNeedsReconnect, setDriveNeedsReconnect] = useState(false);
   const [coupleEmail, setCoupleEmail] = useState<string | null>(null);
@@ -872,7 +700,7 @@ export const DashboardVault: React.FC = () => {
     setTimeout(() => setToasts(prev => prev.filter(t => t.id !== id)), 4000);
   }
 
-  async function forceGoogleDriveProvider(siteId: string) {
+  const forceGoogleDriveProvider = useCallback(async (siteId: string) => {
     if (isDemoMode && siteId === 'demo-site-id') {
       setVaultStorageProvider('google_drive');
       return;
@@ -885,10 +713,10 @@ export const DashboardVault: React.FC = () => {
 
     if (error) throw error;
     setVaultStorageProvider('google_drive');
-  }
+  }, [isDemoMode]);
 
 
-  async function checkGoogleDriveHealth() {
+  const checkGoogleDriveHealth = useCallback(async () => {
     if (!weddingSiteId || (isDemoMode && weddingSiteId === 'demo-site-id')) return;
     setDriveHealthChecking(true);
     try {
@@ -907,7 +735,7 @@ export const DashboardVault: React.FC = () => {
     } finally {
       setDriveHealthChecking(false);
     }
-  }
+  }, [isDemoMode, weddingSiteId]);
 
   async function handleConnectGoogleDrive() {
     if (!weddingSiteId) return;
@@ -987,7 +815,7 @@ export const DashboardVault: React.FC = () => {
     return { vaultConfigs, entries };
   }
 
-  function loadDemoState(): { vaultConfigs: VaultConfig[]; entries: VaultEntry[] } {
+  const loadDemoState = useCallback((): { vaultConfigs: VaultConfig[]; entries: VaultEntry[] } => {
     try {
       const raw = localStorage.getItem(DEMO_VAULT_STORAGE_KEY);
       if (!raw) {
@@ -1011,7 +839,7 @@ export const DashboardVault: React.FC = () => {
       saveDemoState(seeded.vaultConfigs, seeded.entries);
       return seeded;
     }
-  }
+  }, []);
 
   function saveDemoState(nextConfigs: VaultConfig[], nextEntries: VaultEntry[]) {
     localStorage.setItem(DEMO_VAULT_STORAGE_KEY, JSON.stringify({ vaultConfigs: nextConfigs, entries: nextEntries }));
@@ -1141,13 +969,13 @@ setWeddingSiteId('demo-site-id');
     } finally {
       setLoading(false);
     }
-  }, [user, isDemoMode]);
+  }, [forceGoogleDriveProvider, isDemoMode, loadDemoState, user]);
 
   useEffect(() => { loadData(); }, [loadData]);
 
   useEffect(() => {
     if (googleDriveConnected) checkGoogleDriveHealth();
-  }, [googleDriveConnected, weddingSiteId]);
+  }, [checkGoogleDriveHealth, googleDriveConnected, weddingSiteId]);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -1202,7 +1030,7 @@ setWeddingSiteId('demo-site-id');
         }
       })();
     });
-  }, [loadData, weddingSiteId]);
+  }, [checkGoogleDriveHealth, forceGoogleDriveProvider, loadData, weddingSiteId]);
 
   useEffect(() => {
     if (!weddingDate || vaultConfigs.length === 0) return;
@@ -1527,6 +1355,22 @@ setWeddingSiteId('demo-site-id');
   const archiveMode = getArchiveModeDescriptor({ weddingDate: weddingDate ? weddingDate.toISOString() : null });
   const driveConnectedHealthy = googleDriveConnected && !driveNeedsReconnect;
   const showReconnectButton = !googleDriveConnected || driveNeedsReconnect;
+  const vaultMemoryCurator = buildVaultMemoryCuratorModel({
+    configs: vaultConfigs.map((config) => ({
+      id: config.id,
+      duration_years: config.duration_years,
+      is_enabled: config.is_enabled,
+    })),
+    entries: entries.map((entry) => ({
+      vault_config_id: entry.vault_config_id,
+      title: entry.title,
+      author_name: entry.author_name,
+      attachment_name: entry.attachment_name,
+      media_type: entry.media_type,
+    })),
+    isArchiveLike: archiveMode.isArchiveLike,
+    driveConnectedHealthy,
+  });
 
   return (
     <DashboardLayout currentPage="vault">
@@ -1570,6 +1414,8 @@ setWeddingSiteId('demo-site-id');
             <p className="mt-2 text-xs text-stone-700">The event is behind you, so this should start feeling like the center of gravity for memory, anniversary notes, and what the site becomes next.</p>
           )}
         </div>
+
+        <MemoryCuratorCard model={vaultMemoryCurator} />
 
         <Card variant="bordered" padding="md">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">


### PR DESCRIPTION
## Summary
- add a shared memory curator that highlights the next best move across photo collection and anniversary vaults
- enrich the photo bucket cards with quiet readiness signals so the first draft feels more intentional without more UI clutter
- wire the new curator into guest photo sharing and vaults while cleaning unused dead recap plumbing in the touched vault file

## Verification
- npm test -- --run src/lib/memoryCurator.test.ts src/components/dashboard/PhotoBucketCards.test.tsx
- npx eslint src/lib/memoryCurator.ts src/lib/memoryCurator.test.ts src/components/dashboard/MemoryCuratorCard.tsx src/components/dashboard/PhotoBucketCards.tsx src/components/dashboard/PhotoBucketCards.test.tsx src/pages/dashboard/GuestPhotoSharing.tsx src/pages/dashboard/Vault.tsx
- npm run build
- git diff --check -- src/lib/memoryCurator.ts src/lib/memoryCurator.test.ts src/components/dashboard/MemoryCuratorCard.tsx src/components/dashboard/PhotoBucketCards.tsx src/components/dashboard/PhotoBucketCards.test.tsx src/pages/dashboard/GuestPhotoSharing.tsx src/pages/dashboard/Vault.tsx