### PR TITLE
Add vendor fit guidance across planning and profiles

### DIFF
--- a/src/pages/VendorProfile.tsx
+++ b/src/pages/VendorProfile.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { ExternalLink, Instagram } from 'lucide-react';
 import { getVendorProfileBySlug, submitVendorInquiry, type VendorProfile } from '../lib/vendorProfiles';
+import { buildVendorProfileGuide } from './dashboard/planning/vendorDecisionSupport';
 
 function readSourceLink(profile: VendorProfile, key: 'pinterest_url' | 'tiktok_url' | 'facebook_url' | 'youtube_url'): string | null {
   const value = profile.source_payload?.[key];
@@ -72,6 +73,7 @@ export const VendorProfilePage: React.FC = () => {
   const hasDescriptor = Boolean(profile?.descriptor);
   const hasDirectEmail = Boolean(profile?.contact_email);
   const hasPublicLinks = publicLinks.length > 0;
+  const profileGuide = useMemo(() => (profile ? buildVendorProfileGuide(profile) : null), [profile]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -170,6 +172,21 @@ export const VendorProfilePage: React.FC = () => {
 
           <div className="rounded-[28px] bg-white p-6 sm:p-8 shadow-[0_18px_40px_rgba(53,37,22,0.08)] space-y-4 lg:sticky lg:top-6">
             <h2 className="text-sm uppercase tracking-[0.28em] text-[#8b6f53]">Links</h2>
+            {profileGuide && (
+              <div className="rounded-[22px] bg-[#f8f3ec] px-4 py-4 space-y-2">
+                <p className="text-xs uppercase tracking-[0.22em] text-[#8b6f53]">{profileGuide.label}</p>
+                <p className="text-sm font-medium text-[#2f261d]">{profileGuide.title}</p>
+                <p className="text-sm text-[#6f5843]">{profileGuide.detail}</p>
+                <ul className="space-y-1.5 text-sm text-[#6f5843]">
+                  {profileGuide.checks.map((check) => (
+                    <li key={check} className="flex gap-2">
+                      <span className="mt-2 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[#8b6f53]" />
+                      <span>{check}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
             {hasPublicLinks ? (
               <div className="space-y-3">
                 {publicLinks.map((link) => (

--- a/src/pages/dashboard/planning/VendorDecisionDeck.tsx
+++ b/src/pages/dashboard/planning/VendorDecisionDeck.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { ArrowRight, Sparkles } from 'lucide-react';
+import { Card } from '../../../components/ui/Card';
+import type { VendorDecisionDeckModel } from './vendorDecisionSupport';
+
+interface Props {
+  model: VendorDecisionDeckModel;
+  onSelectVendor?: (vendorId: string) => void;
+}
+
+export const VendorDecisionDeck: React.FC<Props> = ({ model, onSelectVendor }) => {
+  const toneClass = (tone: 'urgent' | 'watch' | 'ready') => {
+    if (tone === 'urgent') return 'border-amber-200 bg-amber-50/70';
+    if (tone === 'ready') return 'border-emerald-200 bg-emerald-50/70';
+    return 'border-slate-200 bg-white';
+  };
+
+  return (
+    <Card padding="md" className="border-primary/15 bg-primary/[0.03]">
+      <div className="flex items-start gap-3">
+        <div className="rounded-xl bg-primary/10 p-2">
+          <Sparkles className="h-5 w-5 text-primary" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-secondary">{model.heading}</p>
+          <p className="mt-1 text-sm leading-6 text-text-secondary">{model.summary}</p>
+          <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-text-secondary">
+            {model.badges.map((badge) => (
+              <span key={badge} className="rounded-full bg-white px-2.5 py-1 shadow-sm">
+                {badge}
+              </span>
+            ))}
+          </div>
+          <div className="mt-4 grid gap-3 lg:grid-cols-3">
+            {model.items.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => onSelectVendor?.(item.id)}
+                className={`rounded-2xl border p-4 text-left transition hover:shadow-sm ${toneClass(item.tone)}`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-text-primary">{item.vendorName}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.16em] text-text-tertiary">{item.title}</p>
+                  </div>
+                  {onSelectVendor ? <ArrowRight className="h-4 w-4 text-text-tertiary" /> : null}
+                </div>
+                <p className="mt-3 text-sm leading-6 text-text-secondary">{item.detail}</p>
+                <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-text-secondary">
+                  {item.badges.map((badge) => (
+                    <span key={badge} className="rounded-full bg-white/80 px-2.5 py-1">
+                      {badge}
+                    </span>
+                  ))}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+};

--- a/src/pages/dashboard/planning/VendorsTab.test.tsx
+++ b/src/pages/dashboard/planning/VendorsTab.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { VendorsTab } from './VendorsTab';
+import type { PlanningVendor } from './planningService';
+
+const vendors: PlanningVendor[] = [
+  {
+    id: 'vendor-1',
+    wedding_site_id: 'site-1',
+    vendor_type: 'Photographer',
+    name: 'North Light Studio',
+    contact_name: 'Avery',
+    email: 'hello@northlight.test',
+    phone: '',
+    website: 'https://northlight.test',
+    contract_total: 6000,
+    amount_paid: 2000,
+    balance_due: 4000,
+    next_payment_due: '2026-06-01',
+    notes: 'Warm editorial style',
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-01T00:00:00.000Z',
+  },
+];
+
+describe('VendorsTab', () => {
+  it('renders the vendor fit guide deck', () => {
+    render(
+      <VendorsTab
+        vendors={vendors}
+        onAdd={vi.fn(async () => undefined)}
+        onUpdate={vi.fn(async () => undefined)}
+        onDelete={vi.fn(async () => undefined)}
+      />,
+    );
+
+    expect(screen.getByText('Vendor fit guide')).toBeInTheDocument();
+    expect(screen.getAllByText('North Light Studio').length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/dashboard/planning/VendorsTab.tsx
+++ b/src/pages/dashboard/planning/VendorsTab.tsx
@@ -7,6 +7,9 @@ import { PlanningVendor } from './planningService';
 import { formatVendorDate, isVendorDateOnOrBefore } from './vendorDate';
 import { PlanningDecisionCard } from './PlanningDecisionCard';
 import { buildVendorsDecisionCard } from './planningDecisionAssistant';
+import { readVendorMetaStorage, writeVendorMetaStorage } from './vendorMetaStorage';
+import { buildVendorDecisionDeck, buildVendorFitSummary } from './vendorDecisionSupport';
+import { VendorDecisionDeck } from './VendorDecisionDeck';
 
 interface Props {
   vendors: PlanningVendor[];
@@ -179,8 +182,7 @@ export const VendorsTab: React.FC<Props> = ({ vendors, onAdd, onUpdate, onDelete
 
   React.useEffect(() => {
     try {
-      const raw = localStorage.getItem('dayof.vendor.meta.v1');
-      if (raw) setVendorMeta(JSON.parse(raw));
+      setVendorMeta(readVendorMetaStorage());
     } catch {
       // Ignore malformed local state and fall back to a clean vendor meta map.
     }
@@ -188,7 +190,7 @@ export const VendorsTab: React.FC<Props> = ({ vendors, onAdd, onUpdate, onDelete
 
   React.useEffect(() => {
     try {
-      localStorage.setItem('dayof.vendor.meta.v1', JSON.stringify(vendorMeta));
+      writeVendorMetaStorage(vendorMeta);
     } catch {
       // Ignore storage write failures for optional vendor follow-up metadata.
     }
@@ -228,10 +230,17 @@ export const VendorsTab: React.FC<Props> = ({ vendors, onAdd, onUpdate, onDelete
     paid: filteredVendors.filter((v) => vendorStage(v) === 'paid'),
   };
   const vendorDecision = buildVendorsDecisionCard(vendors);
+  const vendorDeck = buildVendorDecisionDeck(vendors, vendorMeta, today);
 
   return (
     <div className="space-y-4">
       <PlanningDecisionCard model={vendorDecision} />
+      {vendorDeck ? (
+        <VendorDecisionDeck
+          model={vendorDeck}
+          onSelectVendor={(vendorId) => setExpandedId(vendorId)}
+        />
+      ) : null}
 
       {(totalBalance > 0 || followUpDueCount > 0) && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -309,6 +318,7 @@ export const VendorsTab: React.FC<Props> = ({ vendors, onAdd, onUpdate, onDelete
             const isExpanded = expandedId === vendor.id;
             const isDueSoon = Boolean(vendor.balance_due > 0 && isVendorDateOnOrBefore(vendor.next_payment_due, in7Days));
             const balancePct = vendor.contract_total > 0 ? (vendor.amount_paid / vendor.contract_total) * 100 : 0;
+            const fitSummary = buildVendorFitSummary(vendor, vendorMeta, today);
 
             return (
               <div key={vendor.id}>
@@ -326,10 +336,20 @@ export const VendorsTab: React.FC<Props> = ({ vendors, onAdd, onUpdate, onDelete
                           <p className="text-sm font-semibold text-text-primary">{vendor.name}</p>
                           <Badge variant="neutral">{vendor.vendor_type}</Badge>
                           {isDueSoon && <Badge variant="warning">Payment due soon</Badge>}
+                          <span className={`rounded-full px-2 py-0.5 text-[11px] ${
+                            fitSummary.tone === 'urgent'
+                              ? 'bg-amber-100 text-amber-800'
+                              : fitSummary.tone === 'ready'
+                                ? 'bg-emerald-100 text-emerald-800'
+                                : 'bg-slate-100 text-slate-700'
+                          }`}>
+                            {fitSummary.label}
+                          </span>
                         </div>
                         {vendor.contact_name && (
                           <p className="text-xs text-text-tertiary mt-0.5">{vendor.contact_name}</p>
                         )}
+                        <p className="mt-2 text-xs text-text-secondary">{fitSummary.detail}</p>
                         <div className="flex items-center gap-3 mt-2">
                           <div className="flex-1">
                             <div className="flex items-center justify-between text-xs text-text-tertiary mb-1">

--- a/src/pages/dashboard/planning/vendorDecisionSupport.test.ts
+++ b/src/pages/dashboard/planning/vendorDecisionSupport.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { buildVendorDecisionDeck, buildVendorFitSummary, buildVendorProfileGuide } from './vendorDecisionSupport';
+import type { PlanningVendor } from './planningService';
+import type { VendorProfile } from '../../../lib/vendorProfiles';
+
+const vendor = (overrides: Partial<PlanningVendor>): PlanningVendor => ({
+  id: 'vendor-1',
+  wedding_site_id: 'site-1',
+  vendor_type: 'Photographer',
+  name: 'North Light Studio',
+  contact_name: 'Avery',
+  email: 'hello@northlight.test',
+  phone: '',
+  website: 'https://northlight.test',
+  contract_total: 6000,
+  amount_paid: 2000,
+  balance_due: 4000,
+  next_payment_due: '2026-06-01',
+  document_label: '',
+  document_url: '',
+  notes: 'Warm editorial style',
+  created_at: '2026-05-01T00:00:00.000Z',
+  updated_at: '2026-05-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('vendorDecisionSupport', () => {
+  it('marks vendors without direct contact as urgent', () => {
+    const summary = buildVendorFitSummary(
+      vendor({ email: '', phone: '', balance_due: 0, next_payment_due: null }),
+      {},
+      new Date('2026-05-26T12:00:00.000Z'),
+    );
+
+    expect(summary.tone).toBe('urgent');
+    expect(summary.label).toBe('Needs contact path');
+  });
+
+  it('builds a priority deck with the most urgent vendor first', () => {
+    const deck = buildVendorDecisionDeck([
+      vendor({ id: 'v1', name: 'Missing Contact', email: '', phone: '', balance_due: 0, next_payment_due: null }),
+      vendor({ id: 'v2', name: 'Ready Choice', balance_due: 0, amount_paid: 6000, contract_total: 6000, next_payment_due: null }),
+      vendor({ id: 'v3', name: 'Follow Up', balance_due: 0, next_payment_due: null }),
+    ], {
+      v3: { nextFollowUp: '2026-05-27' },
+    }, new Date('2026-05-26T12:00:00.000Z'));
+
+    expect(deck?.items[0].vendorName).toBe('Missing Contact');
+    expect(deck?.badges).toContain('1 urgent');
+  });
+
+  it('builds a public vendor guide from available proof signals', () => {
+    const profile: VendorProfile = {
+      id: 'profile-1',
+      slug: 'north-light',
+      vendor_name: 'North Light Studio',
+      descriptor: 'Warm editorial wedding photography',
+      about: 'A photo team',
+      hero_image_url: 'https://example.com/hero.jpg',
+      image_urls: ['https://example.com/2.jpg', 'https://example.com/3.jpg'],
+      instagram_url: 'https://instagram.com/northlight',
+      website_url: 'https://northlight.test',
+      contact_email: 'hello@northlight.test',
+      source_payload: {},
+    };
+
+    const guide = buildVendorProfileGuide(profile);
+
+    expect(guide.label).toBe('Decision-friendly');
+    expect(guide.checks[0]).toContain('gallery');
+  });
+});

--- a/src/pages/dashboard/planning/vendorDecisionSupport.ts
+++ b/src/pages/dashboard/planning/vendorDecisionSupport.ts
@@ -1,0 +1,227 @@
+import type { VendorProfile } from '../../../lib/vendorProfiles';
+import type { PlanningVendor } from './planningService';
+import type { VendorMetaMap } from './vendorMetaStorage';
+import { isVendorDateOnOrBefore } from './vendorDate';
+
+export interface VendorFitSummary {
+  score: number;
+  tone: 'urgent' | 'watch' | 'ready';
+  label: string;
+  detail: string;
+  badges: string[];
+}
+
+export interface VendorDecisionDeckItem {
+  id: string;
+  tone: 'urgent' | 'watch' | 'ready';
+  title: string;
+  vendorName: string;
+  detail: string;
+  badges: string[];
+}
+
+export interface VendorDecisionDeckModel {
+  heading: string;
+  summary: string;
+  badges: string[];
+  items: VendorDecisionDeckItem[];
+}
+
+export interface VendorProfileGuideModel {
+  label: string;
+  title: string;
+  detail: string;
+  checks: string[];
+}
+
+function createWindows(today = new Date()) {
+  const start = new Date(today);
+  start.setHours(0, 0, 0, 0);
+  const in7Days = new Date(start);
+  in7Days.setDate(in7Days.getDate() + 7);
+  const in21Days = new Date(start);
+  in21Days.setDate(in21Days.getDate() + 21);
+  return { start, in7Days, in21Days };
+}
+
+function countFilled(...values: Array<unknown>) {
+  return values.filter((value) => {
+    if (typeof value === 'string') return Boolean(value.trim());
+    if (typeof value === 'number') return Number.isFinite(value) && value > 0;
+    return Boolean(value);
+  }).length;
+}
+
+export function buildVendorFitSummary(
+  vendor: PlanningVendor,
+  vendorMeta: VendorMetaMap,
+  today = new Date(),
+): VendorFitSummary {
+  const meta = vendorMeta[vendor.id] ?? {};
+  const { in7Days, in21Days } = createWindows(today);
+  const hasDirectContact = countFilled(vendor.email, vendor.phone) > 0;
+  const hasProof = countFilled(vendor.website, vendor.notes) > 0;
+  const hasFinancialClarity = countFilled(vendor.contract_total, vendor.next_payment_due) > 0;
+  const dueSoon = Boolean(vendor.balance_due > 0 && isVendorDateOnOrBefore(vendor.next_payment_due, in7Days));
+  const followUpDue = Boolean(meta.nextFollowUp && isVendorDateOnOrBefore(meta.nextFollowUp, in7Days));
+  const recentlyContacted = Boolean(meta.lastContacted && isVendorDateOnOrBefore(meta.lastContacted, in21Days));
+  const score = countFilled(
+    vendor.contact_name,
+    hasDirectContact,
+    vendor.website,
+    vendor.notes,
+    vendor.contract_total,
+    recentlyContacted,
+  );
+
+  if (!hasDirectContact) {
+    return {
+      score,
+      tone: 'urgent',
+      label: 'Needs contact path',
+      detail: 'Add a real email or phone path before this vendor becomes a serious option.',
+      badges: [
+        vendor.vendor_type,
+        'No direct contact',
+      ],
+    };
+  }
+
+  if (dueSoon) {
+    return {
+      score,
+      tone: 'urgent',
+      label: 'Decision due soon',
+      detail: 'There is money due soon here, so this vendor needs a yes, a plan, or a pause instead of passive tracking.',
+      badges: [
+        vendor.balance_due > 0 ? `${Math.round(vendor.balance_due).toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })} due` : 'Balance open',
+        vendor.next_payment_due ? `Due ${vendor.next_payment_due}` : 'Payment timing unclear',
+      ],
+    };
+  }
+
+  if (followUpDue) {
+    return {
+      score,
+      tone: 'watch',
+      label: 'Follow-up due',
+      detail: 'This vendor already needs a follow-up pass, so keep the loop moving before the thread gets cold.',
+      badges: [
+        vendor.vendor_type,
+        meta.nextFollowUp ? `Follow up ${meta.nextFollowUp}` : 'Follow-up due',
+      ],
+    };
+  }
+
+  if (score >= 5 && hasProof && hasFinancialClarity) {
+    return {
+      score,
+      tone: 'ready',
+      label: 'Ready to choose',
+      detail: 'You have enough contact, proof, and contract context here to make a real decision instead of gathering more trivia.',
+      badges: [
+        vendor.vendor_type,
+        vendor.balance_due > 0 ? 'Contract in motion' : 'Financially calm',
+      ],
+    };
+  }
+
+  return {
+    score,
+    tone: 'watch',
+    label: 'Needs one more pass',
+    detail: 'This vendor is plausible, but one or two missing details are still keeping it from feeling decision-ready.',
+    badges: [
+      vendor.vendor_type,
+      hasProof ? 'Has proof' : 'Needs proof',
+      recentlyContacted ? 'Fresh contact' : 'Contact getting stale',
+    ],
+  };
+}
+
+export function buildVendorDecisionDeck(
+  vendors: PlanningVendor[],
+  vendorMeta: VendorMetaMap,
+  today = new Date(),
+): VendorDecisionDeckModel | null {
+  if (vendors.length === 0) return null;
+
+  const ranked = vendors
+    .map((vendor) => {
+      const summary = buildVendorFitSummary(vendor, vendorMeta, today);
+      const urgencyWeight = summary.tone === 'urgent' ? 3 : summary.tone === 'watch' ? 2 : 1;
+      return {
+        vendor,
+        summary,
+        priority: urgencyWeight * 100 + (10 - Math.min(summary.score, 10)),
+      };
+    })
+    .sort((a, b) => b.priority - a.priority || a.vendor.name.localeCompare(b.vendor.name));
+
+  const urgentCount = ranked.filter((entry) => entry.summary.tone === 'urgent').length;
+  const readyCount = ranked.filter((entry) => entry.summary.tone === 'ready').length;
+  const needsContactCount = ranked.filter((entry) => entry.summary.label === 'Needs contact path').length;
+
+  return {
+    heading: 'Vendor fit guide',
+    summary: urgentCount > 0
+      ? 'These are the vendor decisions most likely to get noisy next. Handle the contact gaps and money timing first, then decide who is genuinely ready.'
+      : 'Your vendor list is stable enough to compare calmly. Focus on who is decision-ready instead of reopening every vendor at once.',
+    badges: [
+      `${urgentCount} urgent`,
+      `${readyCount} ready to choose`,
+      `${needsContactCount} missing direct contact`,
+    ],
+    items: ranked.slice(0, 3).map(({ vendor, summary }) => ({
+      id: vendor.id,
+      tone: summary.tone,
+      title: summary.label,
+      vendorName: vendor.name,
+      detail: summary.detail,
+      badges: summary.badges,
+    })),
+  };
+}
+
+export function buildVendorProfileGuide(profile: VendorProfile): VendorProfileGuideModel {
+  const hasDirectEmail = Boolean(profile.contact_email?.trim());
+  const hasGalleryDepth = [profile.hero_image_url, ...profile.image_urls].filter(Boolean).length >= 3;
+  const hasPublicLinks = countFilled(profile.instagram_url, profile.website_url) > 0;
+  const hasDescriptor = Boolean(profile.descriptor?.trim());
+  const linkCount = countFilled(
+    profile.instagram_url,
+    profile.website_url,
+    typeof profile.source_payload?.pinterest_url === 'string' ? profile.source_payload.pinterest_url : null,
+    typeof profile.source_payload?.tiktok_url === 'string' ? profile.source_payload.tiktok_url : null,
+    typeof profile.source_payload?.facebook_url === 'string' ? profile.source_payload.facebook_url : null,
+    typeof profile.source_payload?.youtube_url === 'string' ? profile.source_payload.youtube_url : null,
+  );
+
+  if (hasDirectEmail && hasGalleryDepth && hasPublicLinks) {
+    return {
+      label: 'Decision-friendly',
+      title: 'This profile gives couples enough signal to move',
+      detail: 'There is enough proof, imagery, and contact clarity here for a couple to decide whether they want the first conversation.',
+      checks: [
+        'Look at the gallery first to see whether the visual style actually fits.',
+        'Use the direct email when you already know you want to reach out.',
+        'Use the public links to verify that recent work still matches the tone here.',
+      ],
+    };
+  }
+
+  return {
+    label: 'Decision guide',
+    title: hasDescriptor
+      ? 'Use the strongest signals first before you reach out'
+      : 'This profile still needs a quick human read before it earns a yes',
+    detail: hasDirectEmail
+      ? 'There is a direct contact path, but couples will still want to pressure-test the available proof before treating this like a shortlist lock.'
+      : 'There is enough here to orient someone, but not enough to replace a quick manual check across links, visuals, and contact path.',
+    checks: [
+      hasGalleryDepth ? 'The images give a decent style signal, so use those before reading every word.' : 'You may need to rely on the public links because the gallery is still light.',
+      hasPublicLinks ? `${linkCount} public link${linkCount === 1 ? '' : 's'} can help verify freshness and fit.` : 'The profile is missing broader public proof, so outreach may need more caution.',
+      hasDirectEmail ? 'Direct email is available once the fit feels real.' : 'Use the inquiry form when you want a low-friction first contact.',
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- add shared vendor fit guidance so the planning vendor list highlights who is decision-ready, who needs contact cleanup, and who needs a follow-up first
- introduce a compact vendor decision deck in the planning tab without turning the vendor flow into a heavier control panel
- add a public vendor profile decision guide so couples can evaluate proof, links, and contact paths faster

## Verification
- npm test -- --run src/pages/dashboard/planning/vendorDecisionSupport.test.ts src/pages/dashboard/planning/VendorsTab.test.tsx
- npx eslint src/pages/dashboard/planning/vendorDecisionSupport.ts src/pages/dashboard/planning/VendorDecisionDeck.tsx src/pages/dashboard/planning/vendorDecisionSupport.test.ts src/pages/dashboard/planning/VendorsTab.test.tsx src/pages/dashboard/planning/VendorsTab.tsx src/pages/VendorProfile.tsx
- npm run build
- git diff --check -- src/pages/dashboard/planning/vendorDecisionSupport.ts src/pages/dashboard/planning/VendorDecisionDeck.tsx src/pages/dashboard/planning/vendorDecisionSupport.test.ts src/pages/dashboard/planning/VendorsTab.test.tsx src/pages/dashboard/planning/VendorsTab.tsx src/pages/VendorProfile.tsx